### PR TITLE
Updating flair to `0.11.1`

### DIFF
--- a/.github/workflows/python-api-flair.yaml
+++ b/.github/workflows/python-api-flair.yaml
@@ -1,0 +1,26 @@
+name: flair-docker
+
+on:
+  pull_request:
+    paths:
+      - "docker_images/flair/**"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install pytest pillow httpx
+          pip install -e .
+      - run: RUN_DOCKER_TESTS=1 pytest -sv tests/test_dockers.py::DockerImageTests::test_flair

--- a/docker_images/flair/app/pipelines/token_classification.py
+++ b/docker_images/flair/app/pipelines/token_classification.py
@@ -28,7 +28,7 @@ class TokenClassificationPipeline(Pipeline):
         sentence: Sentence = Sentence(inputs)
 
         # Also show scores for recognized NEs
-        self.tagger.predict(sentence, all_tag_prob=True, label_name="predicted")
+        self.tagger.predict(sentence, label_name="predicted")
 
         entities = []
         for span in sentence.get_spans("predicted"):
@@ -36,9 +36,9 @@ class TokenClassificationPipeline(Pipeline):
                 continue
             current_entity = {
                 "entity_group": span.tag,
-                "word": span.to_original_text(),
-                "start": span.tokens[0].start_pos,
-                "end": span.tokens[-1].end_pos,
+                "word": span.text,
+                "start": span.tokens[0].start_position,
+                "end": span.tokens[-1].end_position,
                 "score": span.score,
             }
 

--- a/docker_images/flair/requirements.txt
+++ b/docker_images/flair/requirements.txt
@@ -1,4 +1,5 @@
 starlette==0.14.2
 pydantic==1.8.1
 flair==0.11.1
-api-inference-community==0.0.8
+api-inference-community==0.0.23
+huggingface_hub==0.5.1

--- a/docker_images/flair/requirements.txt
+++ b/docker_images/flair/requirements.txt
@@ -1,4 +1,4 @@
 starlette==0.14.2
 pydantic==1.8.1
--e git+https://github.com/flairNLP/flair@master#egg=flair
+flair==0.11.1
 api-inference-community==0.0.8


### PR DESCRIPTION
Rebuilt the old version, but since it's using a non pinned version of `flair` it can cause issues (Lack of Etag seems to be linked to `huggingface_hub` not flair though, but I have seen that there could be some small modifications needed too.? )