### PR TITLE
Add timm to requirements for FastAI

### DIFF
--- a/docker_images/fastai/requirements.txt
+++ b/docker_images/fastai/requirements.txt
@@ -1,3 +1,4 @@
 starlette==0.14.2
 api-inference-community==0.0.23
 huggingface_hub[fastai]==0.6.0
+timm==0.5.4


### PR DESCRIPTION
This adds `timm==0.5.4` to the default requirements for FastAI environments, as per the discussion on Slack: https://huggingface.slack.com/archives/C01BWJU0YKW/p1654712381652479?thread_ts=1654708826.292169&cid=C01BWJU0YKW