### PR TITLE
Sklearn docker tests update

### DIFF
--- a/docker_images/sklearn/README.md
+++ b/docker_images/sklearn/README.md
@@ -19,6 +19,9 @@ SKOPS_TESTS_TOKEN=your_secret_token docker_images/sklearn/tests/generators/run.s
 This script needs to be run _only once_ when you first start developing, or each
 time a new scikit-learn version is released.
 
+The created model repositories are also used for common tests of this package,
+see `tests/test_dockers.py` > `test_sklearn`.
+
 Note that a working [mamba
 installation](https://mamba.readthedocs.io/en/latest/installation.html) is
 required for this step

--- a/tests/test_dockers.py
+++ b/tests/test_dockers.py
@@ -5,6 +5,7 @@ import time
 import unittest
 import uuid
 from collections import Counter
+from typing import Any, Optional
 
 import httpx
 
@@ -147,17 +148,40 @@ class DockerImageTests(unittest.TestCase):
         self.framework_invalid_test("flair")
 
     def test_sklearn(self):
+        clf_data = {
+            "data": {
+                "sepal length (cm)": [6.1, 5.7, 7.7],
+                "sepal width (cm)": [2.8, 3.8, 2.6],
+                "petal length (cm)": [4.7, 1.7, 6.9],
+                "petal width (cm)": [1.2, 0.3, 2.3],
+            }
+        }
         self.framework_docker_test(
             "sklearn",
             "tabular-classification",
-            "julien-c/wine-quality",
+            "skops-tests/iris-sklearn-latest-logistic_regression-with-config",
+            custom_input=clf_data,
         )
 
+        regr_data = {
+            "data": {
+                "age": [0.045, 0.092, 0.063],
+                "sex": [-0.044, -0.044, 0.050],
+                "bmi": [-0.006, 0.036, -0.004],
+                "bp": [-0.015, 0.021, -0.012],
+                "s1": [0.125, -0.024, 0.103],
+                "s2": [0.125, -0.016, 0.048],
+                "s3": [0.019, 0.000, 0.056],
+                "s4": [0.034, -0.039, -0.002],
+                "s5": [0.032, -0.022, 0.084],
+                "s6": [-0.005, -0.021, -0.017],
+            }
+        }
         self.framework_docker_test(
             "sklearn",
             "tabular-regression",
-            # dataset is for classification but regression should also work
-            "julien-c/wine-quality",
+            "skops-tests/tabularregression-sklearn-latest-linear_regression-with-config"
+            custom_input=regr_data,
         )
 
     def test_k2_sherpa(self):
@@ -395,7 +419,13 @@ class DockerImageTests(unittest.TestCase):
             proc.wait()
         self.assertTrue(True)
 
-    def framework_docker_test(self, framework: str, task: str, model_id: str):
+    def framework_docker_test(
+        self,
+        framework: str,
+        task: str,
+        model_id: str,
+            custom_input: Optional[Any],  # if given, check inference with this specific input
+    ):
         tag = self.create_docker(framework)
         run_docker_command = [
             "docker",
@@ -482,6 +512,15 @@ class DockerImageTests(unittest.TestCase):
             )
             self.assertIn(response.status_code, {200, 400})
             counter[response.status_code] += 1
+
+            if custom_input is not None:
+                response = httpx.post(
+                    url,
+                    json=custom_input,
+                    timeout=timeout,
+                )
+                self.assertIn(response.status_code, {200, 400})
+                counter[response.status_code] += 1
 
             with open(
                 os.path.join(os.path.dirname(__file__), "samples", "sample1.flac"), "rb"

--- a/tests/test_dockers.py
+++ b/tests/test_dockers.py
@@ -180,7 +180,7 @@ class DockerImageTests(unittest.TestCase):
         self.framework_docker_test(
             "sklearn",
             "tabular-regression",
-            "skops-tests/tabularregression-sklearn-latest-linear_regression-with-config"
+            "skops-tests/tabularregression-sklearn-latest-linear_regression-with-config",
             custom_input=regr_data,
         )
 

--- a/tests/test_dockers.py
+++ b/tests/test_dockers.py
@@ -424,7 +424,7 @@ class DockerImageTests(unittest.TestCase):
         framework: str,
         task: str,
         model_id: str,
-            custom_input: Optional[Any],  # if given, check inference with this specific input
+        custom_input: Optional[Any],  # if given, check inference with this specific input
     ):
         tag = self.create_docker(framework)
         run_docker_command = [


### PR DESCRIPTION
sklearn tests (tabular classification and regression) failed because the underlying model was using an older version (0.24). Now we use the latest version created via the `docker_images/sklearn/tests/generatos/run.sh` script.

Furthermore, for inference calls to these models to work, we need specific input data, which can now optionally be passed to the `framework_docker_test` function.