### PR TITLE
update the fairseq version to support more models

### DIFF
--- a/docker_images/fairseq/requirements.txt
+++ b/docker_images/fairseq/requirements.txt
@@ -5,5 +5,5 @@ phonemizer==2.2.1
 librosa==0.8.1
 hanziconv==0.3.2
 sentencepiece==0.1.96
-git+https://github.com/pytorch/fairseq.git@5175fd5c267adceec9445bf067597686e159e7e7#egg=fairseq
+git+https://github.com/pytorch/fairseq.git@eda703798dcfde11c1ee517805c27e8698285d71#egg=fairseq
 huggingface_hub==0.5.1


### PR DESCRIPTION
Updating the [version](https://github.com/facebookresearch/fairseq/commit/eda703798dcfde11c1ee517805c27e8698285d71) of fairseq to test new models in the [list](https://github.com/facebookresearch/fairseq/blob/d81fac8163364561fd6cd9d82b6ee1ba502c3526/fairseq/models/speech_to_text/xm_transformer.py#L493).