### PR TITLE
update fairseq version to support vocoder on cpu

### DIFF
--- a/docker_images/fairseq/requirements.txt
+++ b/docker_images/fairseq/requirements.txt
@@ -5,5 +5,5 @@ phonemizer==2.2.1
 librosa==0.8.1
 hanziconv==0.3.2
 sentencepiece==0.1.96
-git+https://github.com/pytorch/fairseq.git@eda703798dcfde11c1ee517805c27e8698285d71#egg=fairseq
+git+https://github.com/pytorch/fairseq.git@37c1573bc3f0e206d2b0909d82c22b6bccb7fa4a#egg=fairseq
 huggingface_hub==0.5.1


### PR DESCRIPTION
Sync fairseq version with https://github.com/facebookresearch/fairseq/pull/4727/commits/37c1573bc3f0e206d2b0909d82c22b6bccb7fa4a to support vocoder on cpu devices 