### PR TITLE
First step towards CD. (Only flair for now)

### DIFF
--- a/.github/workflows/python-api-flair-cd.yaml
+++ b/.github/workflows/python-api-flair-cd.yaml
@@ -1,10 +1,10 @@
 name: flair-docker-cd
 on:
   push:
-    # branches:
-    #   - main
-    # paths:
-    #   - "docker_images/flair/**"
+    branches:
+      - main
+    paths:
+      - "docker_images/flair/**"
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-api-flair-cd.yaml
+++ b/.github/workflows/python-api-flair-cd.yaml
@@ -22,14 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install kubernetes httpx uvicorn awscli
-          sudo snap install kubectl --classic
-          helm plugin install https://github.com/databus23/helm-diff
-      - name: Setup K8S
-        run: |
-          mkdir -p ~/.kube && echo "$PROD_K8S_CONFIG" > ~/.kube/config
-        env:
-          PROD_K8S_CONFIG: "${{ secrets.PROD_K8S_CONFIG }}"
+          pip install awscli
       - name: Update upstream
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/python-api-flair-cd.yaml
+++ b/.github/workflows/python-api-flair-cd.yaml
@@ -1,0 +1,41 @@
+name: flair-docker
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docker_images/flair/**"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install kubernetes httpx uvicorn awscli
+          sudo snap install kubectl --classic
+          helm plugin install https://github.com/databus23/helm-diff
+      - name: Setup K8S
+        run: |
+          mkdir -p ~/.kube && echo "$PROD_K8S_CONFIG" > ~/.kube/config
+        env:
+          PROD_K8S_CONFIG: "${{ secrets.PROD_K8S_CONFIG }}"
+      - name: Update upstream
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          DEFAULT_HOSTNAME: ${{ secrets.DEFAULT_HOSTNAME }}
+        run: |
+          python build_docker.py flair --deploy

--- a/.github/workflows/python-api-flair-cd.yaml
+++ b/.github/workflows/python-api-flair-cd.yaml
@@ -46,5 +46,5 @@ jobs:
           echo ${FLAIR_CPU_TAG}
           # Weird single quote escape mechanism because string interpolation does
           # not work on single quote in bash
-          curl  -H "Authorization: Bearer  ${{ secrets.API_GITHUB_TOKEN }}"   https://api.github.com/repos/huggingface/api-inference/actions/workflows/update_community.yaml/dispatches   -d '{"ref":"adding_action_for_community","inputs":{"framework":"FLAIR","tag": "'"${FLAIR_CPU_TAG}"'"}}'
+          curl  -H "Authorization: Bearer  ${{ secrets.API_GITHUB_TOKEN }}"   https://api.github.com/repos/huggingface/api-inference/actions/workflows/update_community.yaml/dispatches   -d '{"ref":"main","inputs":{"framework":"FLAIR","tag": "'"${FLAIR_CPU_TAG}"'"}}'
 

--- a/.github/workflows/python-api-flair-cd.yaml
+++ b/.github/workflows/python-api-flair-cd.yaml
@@ -41,8 +41,10 @@ jobs:
       - name: Deploy on API
         run: |
           # Load the tags into the env
-          cat out.txt
+          cat out.txt >> $GITHUB_ENV
           export $(xargs < out.txt)
           echo ${FLAIR_CPU_TAG}
-          curl  -H "Authorization: Bearer  ${{ secrets.API_GITHUB_TOKEN }}"   https://api.github.com/repos/huggingface/api-inference/actions/workflows/update_community.yaml/dispatches   -d '{"ref":"adding_action_for_community","inputs":{"framework":"FLAIR","tag": "${FLAIR_CPU_TAG}"}}'
+          # Weird single quote escape mechanism because string interpolation does
+          # not work on single quote in bash
+          curl  -H "Authorization: Bearer  ${{ secrets.API_GITHUB_TOKEN }}"   https://api.github.com/repos/huggingface/api-inference/actions/workflows/update_community.yaml/dispatches   -d '{"ref":"adding_action_for_community","inputs":{"framework":"FLAIR","tag": "'"${FLAIR_CPU_TAG}"'"}}'
 

--- a/.github/workflows/python-api-flair-cd.yaml
+++ b/.github/workflows/python-api-flair-cd.yaml
@@ -43,6 +43,6 @@ jobs:
           # Load the tags into the env
           cat out.txt
           export $(xargs < out.txt)
-          echo ${{ env.FLAIR_CPU_TAG }}
-          curl  -H "Authorization: Bearer  ${{ secrets.API_GITHUB_TOKEN }}"   https://api.github.com/repos/huggingface/api-inference/actions/workflows/update_community.yaml/dispatches   -d '{"ref":"adding_action_for_community","inputs":{"framework":"FLAIR","tag": "${{ env.FLAIR_CPU_TAG }}"}}'
+          echo ${FLAIR_CPU_TAG}
+          curl  -H "Authorization: Bearer  ${{ secrets.API_GITHUB_TOKEN }}"   https://api.github.com/repos/huggingface/api-inference/actions/workflows/update_community.yaml/dispatches   -d '{"ref":"adding_action_for_community","inputs":{"framework":"FLAIR","tag": "${FLAIR_CPU_TAG}"}}'
 

--- a/.github/workflows/python-api-flair-cd.yaml
+++ b/.github/workflows/python-api-flair-cd.yaml
@@ -39,8 +39,6 @@ jobs:
             #   run: |
             #     python build_docker.py flair --deploy
       - name: Deploy on API
-        uses: huggingface/api-inference/.github/workflows/update_community.yaml@main
-        env:
-          INPUT_FRAMEWORK: FLAIR
-          INPUT_TAG: flair-xxxx
+        run: 
+        curl  -H "Authorization: Bearer  ${{ secrets.GITHUB_TOKEN }}"   https://api.github.com/repos/huggingface/api-inference/actions/workflows/update_community.yaml/dispatches   -d '{"ref":"adding_action_for_community","inputs":{"framework":"FLAIR","tag": "flair-xxx"}}'
 

--- a/.github/workflows/python-api-flair-cd.yaml
+++ b/.github/workflows/python-api-flair-cd.yaml
@@ -40,5 +40,5 @@ jobs:
             #     python build_docker.py flair --deploy
       - name: Deploy on API
         run: |
-          curl  -H "Authorization: Bearer  ${{ secrets.GITHUB_TOKEN }}"   https://api.github.com/repos/huggingface/api-inference/actions/workflows/update_community.yaml/dispatches   -d '{"ref":"adding_action_for_community","inputs":{"framework":"FLAIR","tag": "flair-xxx"}}'
+          curl  -H "Authorization: Bearer  ${{ secrets.API_GITHUB_TOKEN }}"   https://api.github.com/repos/huggingface/api-inference/actions/workflows/update_community.yaml/dispatches   -d '{"ref":"adding_action_for_community","inputs":{"framework":"FLAIR","tag": "flair-xxx"}}'
 

--- a/.github/workflows/python-api-flair-cd.yaml
+++ b/.github/workflows/python-api-flair-cd.yaml
@@ -3,8 +3,8 @@ on:
   push:
     # branches:
     #   - main
-    paths:
-      - "docker_images/flair/**"
+    # paths:
+    #   - "docker_images/flair/**"
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-api-flair-cd.yaml
+++ b/.github/workflows/python-api-flair-cd.yaml
@@ -41,6 +41,8 @@ jobs:
       - name: Deploy on API
         run: |
           # Load the tags into the env
+          cat out.txt
           export $(xargs < out.txt)
-          curl  -H "Authorization: Bearer  ${{ secrets.API_GITHUB_TOKEN }}"   https://api.github.com/repos/huggingface/api-inference/actions/workflows/update_community.yaml/dispatches   -d '{"ref":"adding_action_for_community","inputs":{"framework":"FLAIR","tag": "${FLAIR_CPU_TAG}"}}'
+          echo ${{ env.FLAIR_CPU_TAG }}
+          curl  -H "Authorization: Bearer  ${{ secrets.API_GITHUB_TOKEN }}"   https://api.github.com/repos/huggingface/api-inference/actions/workflows/update_community.yaml/dispatches   -d '{"ref":"adding_action_for_community","inputs":{"framework":"FLAIR","tag": "${{ env.FLAIR_CPU_TAG }}"}}'
 

--- a/.github/workflows/python-api-flair-cd.yaml
+++ b/.github/workflows/python-api-flair-cd.yaml
@@ -39,6 +39,6 @@ jobs:
             #   run: |
             #     python build_docker.py flair --deploy
       - name: Deploy on API
-        run: 
-        curl  -H "Authorization: Bearer  ${{ secrets.GITHUB_TOKEN }}"   https://api.github.com/repos/huggingface/api-inference/actions/workflows/update_community.yaml/dispatches   -d '{"ref":"adding_action_for_community","inputs":{"framework":"FLAIR","tag": "flair-xxx"}}'
+        run: |
+          curl  -H "Authorization: Bearer  ${{ secrets.GITHUB_TOKEN }}"   https://api.github.com/repos/huggingface/api-inference/actions/workflows/update_community.yaml/dispatches   -d '{"ref":"adding_action_for_community","inputs":{"framework":"FLAIR","tag": "flair-xxx"}}'
 

--- a/.github/workflows/python-api-flair-cd.yaml
+++ b/.github/workflows/python-api-flair-cd.yaml
@@ -1,9 +1,8 @@
-name: flair-docker
-
+name: flair-docker-cd
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
     paths:
       - "docker_images/flair/**"
 jobs:
@@ -31,11 +30,17 @@ jobs:
           mkdir -p ~/.kube && echo "$PROD_K8S_CONFIG" > ~/.kube/config
         env:
           PROD_K8S_CONFIG: "${{ secrets.PROD_K8S_CONFIG }}"
-      - name: Update upstream
+            # - name: Update upstream
+            #   env:
+            #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            #     AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+            #     DEFAULT_HOSTNAME: ${{ secrets.DEFAULT_HOSTNAME }}
+            #   run: |
+            #     python build_docker.py flair --deploy
+      - name: Deploy on API
+        uses: huggingface/api-inference/.github/workflows/update_community.yaml@main
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-          DEFAULT_HOSTNAME: ${{ secrets.DEFAULT_HOSTNAME }}
-        run: |
-          python build_docker.py flair --deploy
+          INPUT_FRAMEWORK: FLAIR
+          INPUT_TAG: flair-xxxx
+

--- a/.github/workflows/python-api-flair-cd.yaml
+++ b/.github/workflows/python-api-flair-cd.yaml
@@ -30,15 +30,17 @@ jobs:
           mkdir -p ~/.kube && echo "$PROD_K8S_CONFIG" > ~/.kube/config
         env:
           PROD_K8S_CONFIG: "${{ secrets.PROD_K8S_CONFIG }}"
-            # - name: Update upstream
-            #   env:
-            #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-            #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-            #     AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-            #     DEFAULT_HOSTNAME: ${{ secrets.DEFAULT_HOSTNAME }}
-            #   run: |
-            #     python build_docker.py flair --deploy
+      - name: Update upstream
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          DEFAULT_HOSTNAME: ${{ secrets.DEFAULT_HOSTNAME }}
+        run: |
+          python build_docker.py flair --out out.txt
       - name: Deploy on API
         run: |
-          curl  -H "Authorization: Bearer  ${{ secrets.API_GITHUB_TOKEN }}"   https://api.github.com/repos/huggingface/api-inference/actions/workflows/update_community.yaml/dispatches   -d '{"ref":"adding_action_for_community","inputs":{"framework":"FLAIR","tag": "flair-xxx"}}'
+          # Load the tags into the env
+          export $(xargs < out.txt)
+          curl  -H "Authorization: Bearer  ${{ secrets.API_GITHUB_TOKEN }}"   https://api.github.com/repos/huggingface/api-inference/actions/workflows/update_community.yaml/dispatches   -d '{"ref":"adding_action_for_community","inputs":{"framework":"FLAIR","tag": "${FLAIR_CPU_TAG}"}}'
 

--- a/build_docker.py
+++ b/build_docker.py
@@ -52,22 +52,23 @@ def main():
         help="Which framework image to build.",
     )
     parser.add_argument(
-        "--deploy",
-        action="store_true",
-        help="Should we try and update the production",
+        "--out",
+        type=str,
+        help="Where to store the new tags",
     )
     args = parser.parse_args()
 
-    branch = (
-        subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
-        .decode("utf-8")
-        .strip()
-    )
-    if branch != "main":
-        raise Exception(f"Go to branch `main` ({branch})")
+    # branch = (
+    #     subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+    #     .decode("utf-8")
+    #     .strip()
+    # )
+    # TODO put back the sanity checks in place !
+    # if branch != "main":
+    #     raise Exception(f"Go to branch `main` ({branch})")
 
-    print("Pulling")
-    subprocess.run(["git", "pull"])
+    # print("Pulling")
+    # subprocess.run(["git", "pull"])
 
     if args.framework == "all":
         outputs = []
@@ -75,28 +76,16 @@ def main():
             tag = build(framework)
             outputs.append((framework, tag))
 
-        for (framework, tag) in outputs:
-            print(f"{framework.upper()}_CPU_TAG", tag)
-
     else:
         tag = build(args.framework)
         outputs = [(args.framework, tag)]
 
-    if args.deploy:
-        values = [
-            f"models_tag.{framework.upper()}_CPU_TAG={tag}"
-            for framework, tag in outputs
-        ]
-        cmd = [
-            "helm",
-            "upgrade",
-            "prod",
-            "chart/",
-            "--reuse-values",
-            "--set",
-            ",".join(values),
-        ]
-        run(cmd)
+    for (framework, tag) in outputs:
+        name = f"{framework.upper()}_CPU_TAG"
+        print(name, tag)
+        if args.out:
+            with open(args.out, "w") as f:
+                f.write(f"{name}={tag}\n")
 
 
 if __name__ == "__main__":

--- a/build_docker.py
+++ b/build_docker.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+import argparse
+import os
+import subprocess
+import sys
+import uuid
+
+
+def run(command):
+    print(" ".join(command))
+    p = subprocess.run(command)
+    if p.returncode != 0:
+        sys.exit(p.returncode)
+
+
+def build(framework: str):
+    DEFAULT_HOSTNAME = os.getenv("DEFAULT_HOSTNAME")
+    hostname = DEFAULT_HOSTNAME
+    tag_id = str(uuid.uuid4())[:5]
+    tag = f"{framework}-{tag_id}"
+    container_tag = f"{hostname}/api-inference-prod-community:{tag}"
+
+    command = ["docker", "build", f"docker_images/{framework}", "-t", container_tag]
+    run(command)
+
+    command = ["aws", "ecr", "get-login-password"]
+    ecr_login = subprocess.Popen(command, stdout=subprocess.PIPE)
+    docker_login = subprocess.Popen(
+        ["docker", "login", "-u", "AWS", "--password-stdin", hostname],
+        stdin=ecr_login.stdout,
+        stdout=subprocess.PIPE,
+    )
+    docker_login.communicate()
+
+    command = ["docker", "push", container_tag]
+    run(command)
+    return tag
+
+
+def main():
+    frameworks = {
+        dirname for dirname in os.listdir("docker_images") if dirname != "common"
+    }
+    framework_choices = frameworks.copy()
+    framework_choices.add("all")
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "framework",
+        type=str,
+        choices=framework_choices,
+        help="Which framework image to build.",
+    )
+    parser.add_argument(
+        "--deploy",
+        action="store_true",
+        help="Should we try and update the production",
+    )
+    args = parser.parse_args()
+
+    branch = (
+        subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+        .decode("utf-8")
+        .strip()
+    )
+    if branch != "main":
+        raise Exception(f"Go to branch `main` ({branch})")
+
+    print("Pulling")
+    subprocess.run(["git", "pull"])
+
+    if args.framework == "all":
+        outputs = []
+        for framework in frameworks:
+            tag = build(framework)
+            outputs.append((framework, tag))
+
+        for (framework, tag) in outputs:
+            print(f"{framework.upper()}_CPU_TAG", tag)
+
+    else:
+        tag = build(args.framework)
+        outputs = [(args.framework, tag)]
+
+    if args.deploy:
+        values = [
+            f"models_tag.{framework.upper()}_CPU_TAG={tag}"
+            for framework, tag in outputs
+        ]
+        cmd = [
+            "helm",
+            "upgrade",
+            "prod",
+            "chart/",
+            "--reuse-values",
+            "--set",
+            ",".join(values),
+        ]
+        run(cmd)
+
+
+if __name__ == "__main__":
+    main()

--- a/build_docker.py
+++ b/build_docker.py
@@ -58,17 +58,16 @@ def main():
     )
     args = parser.parse_args()
 
-    # branch = (
-    #     subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
-    #     .decode("utf-8")
-    #     .strip()
-    # )
-    # TODO put back the sanity checks in place !
-    # if branch != "main":
-    #     raise Exception(f"Go to branch `main` ({branch})")
+    branch = (
+        subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+        .decode("utf-8")
+        .strip()
+    )
+    if branch != "main":
+        raise Exception(f"Go to branch `main` ({branch})")
 
-    # print("Pulling")
-    # subprocess.run(["git", "pull"])
+    print("Pulling")
+    subprocess.run(["git", "pull"])
 
     if args.framework == "all":
         outputs = []


### PR DESCRIPTION
The goal is to automatically deploy on merge.
The helm prod chart lives in another repo, ideally we trigger
another action in this other repo (it's simpler). 

The building and uploading can happen here, we just need to add some secrets to this repo.

Feedback welcome on the approach.

Ideally I would like to have a single CD action, that would just check at the modified folders and deploy every folder hit in `docker_images`.

This seems doable however not highly stable (depends on the trigger of the action to get the correct git commands)

Requires: https://github.com/huggingface/api-inference/pull/1151