### PR TITLE
Add warnings to error response for sklearn Pipelines

### DIFF
--- a/docker_images/sklearn/app/pipelines/common.py
+++ b/docker_images/sklearn/app/pipelines/common.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import warnings
+from abc import abstractmethod
 from pathlib import Path
 from typing import Any
 
@@ -60,17 +61,21 @@ class SklearnBasePipeline(Pipeline):
         # to the model in the right order.
         self.columns = config.get("sklearn", {}).get("columns", None)
 
+    @abstractmethod
     def _get_output(self, inputs: Any) -> Any:
         raise NotImplementedError(
             "Implement this method to get the model output (prediction)"
         )
 
-    def handle_call(self, inputs: Any) -> Any:
+    def __call__(self, inputs: Any) -> Any:
         """Handle call for getting the model prediction
 
         This method is responsible for handling all possible errors and
         warnings. To get the actual prediction, implement the `_get_output`
         method.
+
+        The types of the inputs and output depend on the specific task being
+        implemented.
 
         """
         if self._load_exception:

--- a/docker_images/sklearn/app/pipelines/common.py
+++ b/docker_images/sklearn/app/pipelines/common.py
@@ -5,9 +5,8 @@ from pathlib import Path
 from typing import Any
 
 import joblib
-from huggingface_hub import snapshot_download
-
 from app.pipelines import Pipeline
+from huggingface_hub import snapshot_download
 
 
 logger = logging.getLogger(__name__)
@@ -24,6 +23,7 @@ class SklearnBasePipeline(Pipeline):
       annotations.
 
     """
+
     def __init__(self, model_id: str):
         cached_folder = snapshot_download(repo_id=model_id)
         self._load_warnings = []

--- a/docker_images/sklearn/app/pipelines/common.py
+++ b/docker_images/sklearn/app/pipelines/common.py
@@ -1,16 +1,29 @@
 import json
+import logging
 import warnings
 from pathlib import Path
+from typing import Any
 
 import joblib
-from app.pipelines import Pipeline
 from huggingface_hub import snapshot_download
 
+from app.pipelines import Pipeline
 
+
+logger = logging.getLogger(__name__)
 DEFAULT_FILENAME = "sklearn_model.joblib"
 
 
 class SklearnBasePipeline(Pipeline):
+    """Base class for sklearn-based inference pipelines
+
+    Concrete implementations should add two methods:
+
+    - `_get_output`: Method to generate model predictions
+    - `__call__`: Should delegate to handle_call, add docstring and type
+      annotations.
+
+    """
     def __init__(self, model_id: str):
         cached_folder = snapshot_download(repo_id=model_id)
         self._load_warnings = []
@@ -46,3 +59,78 @@ class SklearnBasePipeline(Pipeline):
         # use column names from the config file if available, to give the data
         # to the model in the right order.
         self.columns = config.get("sklearn", {}).get("columns", None)
+
+    def _get_output(self, inputs: Any) -> Any:
+        raise NotImplementedError(
+            "Implement this method to get the model output (prediction)"
+        )
+
+    def handle_call(self, inputs: Any) -> Any:
+        """Handle call for getting the model prediction
+
+        This method is responsible for handling all possible errors and
+        warnings. To get the actual prediction, implement the `_get_output`
+        method.
+
+        """
+        if self._load_exception:
+            # there has been an error while loading the model. We need to raise
+            # that, and can't call predict on the model.
+            raise ValueError(
+                "An error occurred while loading the model: "
+                f"{str(self._load_exception)}"
+            )
+
+        _warnings = []
+        if self.columns:
+            # TODO: we should probably warn if columns are not configured, we
+            # really do need them.
+            given_cols = set(inputs["data"].keys())
+            expected = set(self.columns)
+            extra = given_cols - expected
+            missing = expected - given_cols
+            if extra:
+                _warnings.append(
+                    f"The following columns were given but not expected: {extra}"
+                )
+
+            if missing:
+                _warnings.append(
+                    f"The following columns were expected but not given: {missing}"
+                )
+
+        exception = None
+        try:
+            with warnings.catch_warnings(record=True) as record:
+                res = self._get_output(inputs)
+        except Exception as e:
+            exception = e
+
+        for warning in record:
+            _warnings.append(f"{warning.category.__name__}({warning.message})")
+
+        for warning in self._load_warnings:
+            _warnings.append(f"{warning.category.__name__}({warning.message})")
+
+        if _warnings:
+            for warning in _warnings:
+                logger.warning(warning)
+
+            if not exception:
+                # we raise an error if there are any warnings, so that routes.py
+                # can catch and return a non 200 status code.
+                error = {
+                    "error": "There were warnings while running the model.",
+                    "output": res,
+                    "warnings": _warnings,  # see issue #96
+                }
+                raise ValueError(json.dumps(error))
+            else:
+                # if there was an exception, we raise it so that routes.py can
+                # catch and return a non 200 status code.
+                raise exception
+
+        if exception:
+            raise exception
+
+        return res

--- a/docker_images/sklearn/app/pipelines/tabular_classification.py
+++ b/docker_images/sklearn/app/pipelines/tabular_classification.py
@@ -1,16 +1,23 @@
-import json
-import logging
-import warnings
 from typing import Dict, List, Union
 
 import pandas as pd
+
 from app.pipelines.common import SklearnBasePipeline
 
 
-logger = logging.getLogger(__name__)
-
-
 class TabularClassificationPipeline(SklearnBasePipeline):
+    def _get_output(
+        self, inputs: Dict[str, Dict[str, List[Union[str, float]]]]
+    ) -> List[Union[str, float]]:
+        # We convert the inputs to a pandas DataFrame, and use self.columns
+        # to order the columns in the order they're expected, ignore extra
+        # columns given if any, and put NaN for missing columns.
+        data = pd.DataFrame(inputs["data"], columns=self.columns)
+        res = self.model.predict(data).tolist()
+        return res
+
+    # even though we only call super, we implement this method to update the
+    # docstring and the type annotation
     def __call__(
         self, inputs: Dict[str, Dict[str, List[Union[str, float]]]]
     ) -> List[Union[str, float]]:
@@ -24,67 +31,4 @@ class TabularClassificationPipeline(SklearnBasePipeline):
             A :obj:`list` of floats or strings: The classification output for
             each row.
         """
-        if self._load_exception:
-            # there has been an error while loading the model. We need to raise
-            # that, and can't call predict on the model.
-            raise ValueError(
-                "An error occurred while loading the model: "
-                f"{str(self._load_exception)}"
-            )
-
-        _warnings = []
-        if self.columns:
-            # TODO: we should probably warn if columns are not configured, we
-            # really do need them.
-            given_cols = set(inputs["data"].keys())
-            expected = set(self.columns)
-            extra = given_cols - expected
-            missing = expected - given_cols
-            if extra:
-                _warnings.append(
-                    f"The following columns were given but not expected: {extra}"
-                )
-
-            if missing:
-                _warnings.append(
-                    f"The following columns were expected but not given: {missing}"
-                )
-
-        exception = None
-        try:
-            with warnings.catch_warnings(record=True) as record:
-                # We convert the inputs to a pandas DataFrame, and use self.columns
-                # to order the columns in the order they're expected, ignore extra
-                # columns given if any, and put NaN for missing columns.
-                data = pd.DataFrame(inputs["data"], columns=self.columns)
-                res = self.model.predict(data).tolist()
-        except Exception as e:
-            exception = e
-
-        for warning in record:
-            _warnings.append(f"{warning.category.__name__}({warning.message})")
-
-        for warning in self._load_warnings:
-            _warnings.append(f"{warning.category.__name__}({warning.message})")
-
-        if _warnings:
-            for warning in _warnings:
-                logger.warning(warning)
-
-            if not exception:
-                # we raise an error if there are any warnings, so that routes.py
-                # can catch and return a non 200 status code.
-                error = {
-                    "error": "There were warnings while running the model.",
-                    "output": res,
-                }
-                raise ValueError(json.dumps(error))
-            else:
-                # if there was an exception, we raise it so that routes.py can
-                # catch and return a non 200 status code.
-                raise exception
-
-        if exception:
-            raise exception
-
-        return res
+        return super().handle_call(inputs)

--- a/docker_images/sklearn/app/pipelines/tabular_classification.py
+++ b/docker_images/sklearn/app/pipelines/tabular_classification.py
@@ -14,20 +14,3 @@ class TabularClassificationPipeline(SklearnBasePipeline):
         data = pd.DataFrame(inputs["data"], columns=self.columns)
         res = self.model.predict(data).tolist()
         return res
-
-    # even though we only delegate the call, we implement this method to have
-    # the correct docstring and type annotations
-    def __call__(
-        self, inputs: Dict[str, Dict[str, List[Union[str, float]]]]
-    ) -> List[Union[str, float]]:
-        """Return the output of the model for given inputs.
-
-        Args:
-            inputs (:obj:`dict`):
-                a dictionary containing a key 'data' mapping to a dict in which
-                the values represent each column.
-        Return:
-            A :obj:`list` of floats or strings: The classification output for
-            each row.
-        """
-        return self.handle_call(inputs)

--- a/docker_images/sklearn/app/pipelines/tabular_classification.py
+++ b/docker_images/sklearn/app/pipelines/tabular_classification.py
@@ -15,8 +15,8 @@ class TabularClassificationPipeline(SklearnBasePipeline):
         res = self.model.predict(data).tolist()
         return res
 
-    # even though we only delegate the call, we implement this method have the
-    # correct docstring and type annotations
+    # even though we only delegate the call, we implement this method to have
+    # the correct docstring and type annotations
     def __call__(
         self, inputs: Dict[str, Dict[str, List[Union[str, float]]]]
     ) -> List[Union[str, float]]:

--- a/docker_images/sklearn/app/pipelines/tabular_classification.py
+++ b/docker_images/sklearn/app/pipelines/tabular_classification.py
@@ -15,8 +15,8 @@ class TabularClassificationPipeline(SklearnBasePipeline):
         res = self.model.predict(data).tolist()
         return res
 
-    # even though we only call super, we implement this method to update the
-    # docstring and the type annotation
+    # even though we only delegate the call, we implement this method have the
+    # correct docstring and type annotations
     def __call__(
         self, inputs: Dict[str, Dict[str, List[Union[str, float]]]]
     ) -> List[Union[str, float]]:
@@ -30,4 +30,4 @@ class TabularClassificationPipeline(SklearnBasePipeline):
             A :obj:`list` of floats or strings: The classification output for
             each row.
         """
-        return super().handle_call(inputs)
+        return self.handle_call(inputs)

--- a/docker_images/sklearn/app/pipelines/tabular_classification.py
+++ b/docker_images/sklearn/app/pipelines/tabular_classification.py
@@ -1,7 +1,6 @@
 from typing import Dict, List, Union
 
 import pandas as pd
-
 from app.pipelines.common import SklearnBasePipeline
 
 

--- a/docker_images/sklearn/app/pipelines/text_classification.py
+++ b/docker_images/sklearn/app/pipelines/text_classification.py
@@ -10,6 +10,14 @@ logger = logging.getLogger(__name__)
 
 
 class TextClassificationPipeline(SklearnBasePipeline):
+    def _get_output(self, inputs: str) -> List[Dict[str, float]]:
+        res = []
+        for i, c in enumerate(self.model.predict_proba([inputs]).tolist()[0]):
+            res.append({"label": str(self.model.classes_[i]), "score": c})
+        return [res]
+
+    # even though we only call super, we implement this method to update the
+    # docstring and the type annotation
     def __call__(self, inputs: str) -> List[Dict[str, float]]:
         """
         Args:
@@ -20,49 +28,4 @@ class TextClassificationPipeline(SklearnBasePipeline):
                 - "label": A string representing what the label/class is. There can be multiple labels.
                 - "score": A score between 0 and 1 describing how confident the model is for this label/class.
         """
-        if self._load_exception:
-            # there has been an error while loading the model. We need to raise
-            # that, and can't call predict on the model.
-            raise ValueError(
-                "An error occurred while loading the model: "
-                f"{str(self._load_exception)}"
-            )
-
-        _warnings = []
-        exception = None
-        try:
-            with warnings.catch_warnings(record=True) as record:
-                # We will predict probabilities for each class and return them as
-                # list of list of dictionaries
-                # below is a numpy array of probabilities of each class
-                res = []
-                for i, c in enumerate(self.model.predict_proba([inputs]).tolist()[0]):
-                    res.append({"label": str(self.model.classes_[i]), "score": c})
-                res = [res]
-        except Exception as e:
-            exception = e
-
-        for warning in record:
-            _warnings.append(f"{warning.category.__name__}({warning.message})")
-
-        for warning in self._load_warnings:
-            _warnings.append(f"{warning.category.__name__}({warning.message})")
-
-        if _warnings:
-            for warning in _warnings:
-                logger.warning(warning)
-
-            if not exception:
-                # we raise an error if there are any warnings, so that routes.py
-                # can catch and return a non 200 status code.
-                error = {
-                    "error": "There were warnings while running the model.",
-                    "output": res,
-                }
-                raise ValueError(json.dumps(error))
-            else:
-                # if there was an exception, we raise it so that routes.py can
-                # catch and return a non 200 status code.
-                raise exception
-
-        return res
+        return super().handle_call(inputs)

--- a/docker_images/sklearn/app/pipelines/text_classification.py
+++ b/docker_images/sklearn/app/pipelines/text_classification.py
@@ -10,8 +10,8 @@ class TextClassificationPipeline(SklearnBasePipeline):
             res.append({"label": str(self.model.classes_[i]), "score": c})
         return [res]
 
-    # even though we only delegate the call, we implement this method have the
-    # correct docstring and type annotations
+    # even though we only delegate the call, we implement this method to have
+    # the correct docstring and type annotations
     def __call__(self, inputs: str) -> List[Dict[str, float]]:
         """
         Args:

--- a/docker_images/sklearn/app/pipelines/text_classification.py
+++ b/docker_images/sklearn/app/pipelines/text_classification.py
@@ -1,12 +1,6 @@
-import json
-import logging
-import warnings
 from typing import Dict, List
 
 from app.pipelines.common import SklearnBasePipeline
-
-
-logger = logging.getLogger(__name__)
 
 
 class TextClassificationPipeline(SklearnBasePipeline):

--- a/docker_images/sklearn/app/pipelines/text_classification.py
+++ b/docker_images/sklearn/app/pipelines/text_classification.py
@@ -10,8 +10,8 @@ class TextClassificationPipeline(SklearnBasePipeline):
             res.append({"label": str(self.model.classes_[i]), "score": c})
         return [res]
 
-    # even though we only call super, we implement this method to update the
-    # docstring and the type annotation
+    # even though we only delegate the call, we implement this method have the
+    # correct docstring and type annotations
     def __call__(self, inputs: str) -> List[Dict[str, float]]:
         """
         Args:
@@ -22,4 +22,4 @@ class TextClassificationPipeline(SklearnBasePipeline):
                 - "label": A string representing what the label/class is. There can be multiple labels.
                 - "score": A score between 0 and 1 describing how confident the model is for this label/class.
         """
-        return super().handle_call(inputs)
+        return self.handle_call(inputs)

--- a/docker_images/sklearn/app/pipelines/text_classification.py
+++ b/docker_images/sklearn/app/pipelines/text_classification.py
@@ -9,17 +9,3 @@ class TextClassificationPipeline(SklearnBasePipeline):
         for i, c in enumerate(self.model.predict_proba([inputs]).tolist()[0]):
             res.append({"label": str(self.model.classes_[i]), "score": c})
         return [res]
-
-    # even though we only delegate the call, we implement this method to have
-    # the correct docstring and type annotations
-    def __call__(self, inputs: str) -> List[Dict[str, float]]:
-        """
-        Args:
-            inputs (:obj:`str`):
-                a string containing some text
-        Return:
-            A :obj:`list`:. The object returned should be a list of one list like [[{"label": 0.9939950108528137}]] containing:
-                - "label": A string representing what the label/class is. There can be multiple labels.
-                - "score": A score between 0 and 1 describing how confident the model is for this label/class.
-        """
-        return self.handle_call(inputs)

--- a/docker_images/sklearn/tests/test_api_tabular_classification.py
+++ b/docker_images/sklearn/tests/test_api_tabular_classification.py
@@ -88,11 +88,18 @@ class TabularClassificationTestCase(TestCase):
         with TestClient(self.app) as client:
             response = client.post("/", json={"inputs": data})
 
+        # check response
         assert response.status_code == 400
         content = json.loads(response.content)
         assert "error" in content
         assert "warnings" in content
+
+        # check warnings
         assert any("Trying to unpickle estimator" in w for w in content["warnings"])
+        warnings = json.loads(content["error"])["warnings"]
+        assert any("Trying to unpickle estimator" in w for w in warnings)
+
+        # check error
         error_message = json.loads(content["error"])
         assert error_message["output"] == self.expected_output
 

--- a/docker_images/sklearn/tests/test_api_tabular_regression.py
+++ b/docker_images/sklearn/tests/test_api_tabular_regression.py
@@ -93,12 +93,18 @@ class TabularRegressionTestCase(TestCase):
         with TestClient(self.app) as client:
             response = client.post("/", json={"inputs": data})
 
+        # check response
         assert response.status_code == 400
         content = json.loads(response.content)
         assert "error" in content
         assert "warnings" in content
-        assert any("Trying to unpickle estimator" in w for w in content["warnings"])
 
+        # check warnings
+        assert any("Trying to unpickle estimator" in w for w in content["warnings"])
+        warnings = json.loads(content["error"])["warnings"]
+        assert any("Trying to unpickle estimator" in w for w in warnings)
+
+        # check error
         error_message = json.loads(content["error"])
         assert len(error_message["output"]) == len(self.expected_output)
         for val_output, val_expected in zip(

--- a/docker_images/sklearn/tests/test_api_text_classification.py
+++ b/docker_images/sklearn/tests/test_api_text_classification.py
@@ -91,11 +91,18 @@ class TextClassificationTestCase(TestCase):
         with TestClient(self.app) as client:
             response = client.post("/", json={"inputs": data["data"][0]})
 
+        # check response
         assert response.status_code == 400
         content = json.loads(response.content)
         assert "error" in content
         assert "warnings" in content
+
+        # check warnings
         assert any("Trying to unpickle estimator" in w for w in content["warnings"])
+        warnings = json.loads(content["error"])["warnings"]
+        assert any("Trying to unpickle estimator" in w for w in warnings)
+
+        # check error
         error_message = json.loads(content["error"])
         assert error_message["output"] == self.expected_output
 


### PR DESCRIPTION
See #92

When calling the prediction pipeline produces warnings, it is treated as an error. This includes situations where the model output *might* be correct but we're not sure, most notably when there is a mismatch of the version of the loaded sklearn model and the sklearn version of the runtime.

Although we still return the model outputs to the user, we don't show them what warnings were actually encountered. This makes debugging difficult. Therefore, we want to show them the warnings.

This requires two changes. First, we need to add the encountered warnings to the response. Second, we need to display these warnings. This PR implements the first step.

On top of that, this PR introduces a small refactoring to reduce the amount of code duplication (see the last paragraph of [this comment](https://github.com/huggingface/api-inference-community/pull/92#issuecomment-1231776124)). This refactoring results in no functional changes.