### PR TITLE
fix generation issue and remove unit text for s2ut models

### DIFF
--- a/docker_images/fairseq/app/pipelines/audio_to_audio.py
+++ b/docker_images/fairseq/app/pipelines/audio_to_audio.py
@@ -33,14 +33,10 @@ class SpeechToSpeechPipeline(Pipeline):
         tgt_lang = self.task.data_cfg.hub.get("tgt_lang", None)
         pfx = f"{tgt_lang}_" if self.task.data_cfg.prepend_tgt_lang_tag else ""
 
-        generation_beam = self.task.data_cfg.hub.get(f"{pfx}generation_beam", None)
-        if generation_beam is not None:
-            cfg["generation"].beam = generation_beam
-        generation_max_len_a = self.task.data_cfg.hub.get(
-            f"{pfx}generation_max_len_a", None
-        )
-        if generation_max_len_a is not None:
-            cfg["generation"].max_len_a = generation_max_len_a
+        generation_args = self.task.data_cfg.hub.get(f"{pfx}generation_args", None)
+        if generation_args is not None:
+            for key in generation_args:
+                setattr(cfg.generation, key, generation_args[key])
         self.generator = task.build_generator([self.model], cfg.generation)
 
         tts_model_id = self.task.data_cfg.hub.get(f"{pfx}tts_model_id", None)

--- a/docker_images/fairseq/app/pipelines/audio_to_audio.py
+++ b/docker_images/fairseq/app/pipelines/audio_to_audio.py
@@ -36,11 +36,13 @@ class SpeechToSpeechPipeline(Pipeline):
         generation_beam = self.task.data_cfg.hub.get(f"{pfx}generation_beam", None)
         if generation_beam is not None:
             cfg["generation"].beam = generation_beam
-        generation_max_len_a = self.task.data_cfg.hub.get(f"{pfx}generation_max_len_a", None)
+        generation_max_len_a = self.task.data_cfg.hub.get(
+            f"{pfx}generation_max_len_a", None
+        )
         if generation_max_len_a is not None:
             cfg["generation"].max_len_a = generation_max_len_a
         self.generator = task.build_generator([self.model], cfg.generation)
-        
+
         tts_model_id = self.task.data_cfg.hub.get(f"{pfx}tts_model_id", None)
         self.unit_vocoder = self.task.data_cfg.hub.get(f"{pfx}unit_vocoder", None)
         self.tts_model, self.tts_task, self.tts_generator = None, None, None


### PR DESCRIPTION
Some changes in this commit:
- Add `beam` and `max_len_a` configuration to fix generation issue to avoid duration limitations of translation results.
- Replace the unit text output of S2UT models with an empty string. 
- Remove `cpu=true`, local test passed with `pytest -sv --rootdir docker_images/fairseq/ docker_images/fairseq/` , maybe need to further check after it is deployed.