### PR TITLE
Update flair version to support latest models

### DIFF
--- a/docker_images/flair/requirements.txt
+++ b/docker_images/flair/requirements.txt
@@ -1,5 +1,4 @@
 starlette==0.14.2
 pydantic==1.8.1
 flair @ git+https://github.com/flairNLP/flair@d4ed67bf663e4066517f00397412510d90043653
-api-inference-community==0.0.23
-huggingface_hub==0.5.1
+api-inference-community==0.0.25

--- a/docker_images/flair/requirements.txt
+++ b/docker_images/flair/requirements.txt
@@ -1,5 +1,5 @@
 starlette==0.14.2
 pydantic==1.8.1
-flair==0.11.1
+flair @ git+https://github.com/flairNLP/flair@d4ed67bf663e4066517f00397412510d90043653
 api-inference-community==0.0.23
 huggingface_hub==0.5.1


### PR DESCRIPTION
Update flair version to support word and transformer embeddings on widget and inference API.

Some models are only working with latest versions of flair.

For example: This [example of flair 0.11.3 model](https://huggingface.co/lighthousefeed/yoda-ner) only works with latest commit of the library.
You can check it here: [colab notebook](https://colab.research.google.com/drive/1EnL0IFLVN1FDO1x42r13A8oZsfdBcHPg?usp=sharing)