### PR TITLE
Update the fairseq version for hk models

### DIFF
--- a/docker_images/fairseq/app/pipelines/audio_to_audio.py
+++ b/docker_images/fairseq/app/pipelines/audio_to_audio.py
@@ -43,7 +43,7 @@ class SpeechToSpeechPipeline(Pipeline):
         self.unit_vocoder = self.task.data_cfg.hub.get(f"{pfx}unit_vocoder", None)
         self.tts_model, self.tts_task, self.tts_generator = None, None, None
         if tts_model_id is not None:
-            _repo, _id = tts_model_id.split(":")
+            _id = tts_model_id.split(":")[-1]
             cache_dir = os.getenv("HUGGINGFACE_HUB_CACHE")
             if self.unit_vocoder is not None:
                 library_name = "fairseq"

--- a/docker_images/fairseq/requirements.txt
+++ b/docker_images/fairseq/requirements.txt
@@ -6,5 +6,5 @@ librosa==0.8.1
 hanziconv==0.3.2
 sentencepiece==0.1.96
 # Dummy comment to trigger automatic deploy.
-git+https://github.com/pytorch/fairseq.git@655f619667f4c8cf5c5f75c659edfb595e766524#egg=fairseq
+git+https://github.com/pytorch/fairseq.git@679321804cd9de41eeb76668e28d24c8470fda14#egg=fairseq
 huggingface_hub==0.5.1


### PR DESCRIPTION
Update the fairseq version to https://github.com/facebookresearch/fairseq/pull/4776 and a small change for reading the model id from hf repo
Test passed with `pytest -sv --rootdir docker_images/fairseq/ docker_images/fairseq/`