### PR TITLE
update fairseq to stable commit

### DIFF
--- a/docker_images/fairseq/requirements.txt
+++ b/docker_images/fairseq/requirements.txt
@@ -6,5 +6,5 @@ librosa==0.8.1
 hanziconv==0.3.2
 sentencepiece==0.1.96
 # Dummy comment to trigger automatic deploy.
-git+https://github.com/facebookresearch/fairseq.git@d47119871c2ac9a0a0aa2904dd8cfc1929b113d9#egg=fairseq
+git+https://github.com/facebookresearch/fairseq.git@59d966a92aabc68b6e0fe1f7bc3eeccbbbe91413#egg=fairseq
 huggingface_hub==0.5.1


### PR DESCRIPTION
Current version of `fairseq` is causing issues in STT pipeline so I changed it to the last commit of stable release of `fairseq`.

current: `d47119871c2ac9a0a0aa2904dd8cfc1929b113d9`
last: `59d966a92aabc68b6e0fe1f7bc3eeccbbbe91413 `

Error reproduce:
https://www.kaggle.com/code/bayartsogtya/notebooke77335cbe2/notebook
version 1 -> d471198
version 2 -> 59d966

[link to huggingface failed example](https://huggingface.co/bayartsogt/tts_transformer-mn-mbspeech?text=%D1%8D%D0%BD%D1%8D%D1%85%D2%AF%D2%AF+%D0%B0%D0%B6%D0%BB%D1%8B%D0%BD+%D0%B8%D1%85%D1%8D%D0%BD%D1%85+%D1%85%D1%8D%D1%81%D0%B3%D0%B8%D0%B9%D0%B3%2C+%D1%82%D3%A9%D0%B3%D3%A9%D0%BB%D0%B4%D3%A9%D1%80+%D0%B0%D1%85+%D1%85%D0%B8%D0%B9%D1%81%D1%8D%D0%BD+%D0%B1%D0%BE%D0%BB%D0%BD%D0%BE)