### PR TITLE
Change flake8 repo link in pre commit file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8 
     rev: 3.8.3
     hooks:
       - id: flake8


### PR DESCRIPTION
Flake8 has moved from Gitlab to Github. For this reason, there may be problems with some CI/CD processes. 
With this PR, the pre-commit file has been updated and the current flake8 link has been given.