### PR TITLE
Fix backwards compatibility for inference API for scikit-learn models with no config

### DIFF
--- a/docker_images/sklearn/app/pipelines/common.py
+++ b/docker_images/sklearn/app/pipelines/common.py
@@ -37,7 +37,7 @@ class SklearnBasePipeline(Pipeline):
                 config = json.load(f)
         except Exception:
             config = dict()
-            raise UserWarning("`config.json` does not exist or is invalid.")
+            warnings.warn("`config.json` does not exist or is invalid.")
 
         self.model_file = (
             config.get("sklearn", {}).get("model", {}).get("file", DEFAULT_FILENAME)


### PR DESCRIPTION
My previous PR was raising a UserWarning which results in inference API to break when there's no config.json in scikit-learn models. (which applies to all the sklearn models not uploaded with skops) so I swapped raising `UserWarning` with `warnings.warn` instead.
*(to me it doesn't make any sense when a widget doesn't include example input anyway which doesn't come with a scikit-learn model itself but it's discussion for another day)*
![Ekran Resmi 2023-01-24 16 47 54](https://user-images.githubusercontent.com/53175384/214340748-05d00240-1024-44dc-9b19-e9405b81d46f.png)
