### PR TITLE
Change input format on call for better compatibility with kwargs

### DIFF
--- a/docker_images/diffusers/app/pipelines/text_to_image.py
+++ b/docker_images/diffusers/app/pipelines/text_to_image.py
@@ -65,9 +65,9 @@ class TextToImagePipeline(Pipeline):
             if "num_inference_steps" not in kwargs:
                 kwargs["num_inference_steps"] = 25
             images = self.ldm(
-                [inputs],
+                inputs,
                 **kwargs,
             )["images"]
         else:
-            images = self.ldm([inputs], **kwargs)["images"]
+            images = self.ldm(inputs, **kwargs)["images"]
         return images[0]


### PR DESCRIPTION
As we always have a batch size of 1 for a single prompt, let's improve compatibility with kwargs. For instance, use:
```
inputs: "...prompt",
parameters {
  negative_prompt: "....negative_prompt"
}
```
instead of:
```
inputs: "...prompt",
parameters {
  negative_prompt: ["....negative_prompt"]
}
```

currently if you don't send negative_prompt as a list you get this error

```
{"error":"`negative_prompt` should be the same type to `prompt`, but got <class 'str'> != <class 'list'>."}
```