### PR TITLE
Upgradign sentence transformers (huggingface_hub version).

### DIFF
--- a/docker_images/sentence_transformers/requirements.txt
+++ b/docker_images/sentence_transformers/requirements.txt
@@ -1,5 +1,5 @@
 starlette==0.25.0
-api-inference-community==0.0.23
+api-inference-community==0.0.29
 sentence-transformers==2.2.2
 protobuf==3.18.3
-huggingface_hub==0.5.1
+huggingface_hub==0.13.4


### PR DESCRIPTION
Should fix https://huggingface.co/sentence-transformers/paraphrase-xlm-r-multilingual-v1

Which is currently bugged (it seems that the old huggingface_hub is not properly respecting the HEAD/GET requests with tokens which are necessary for sentence-transformers, leading to BAD requests)