### PR TITLE
More fixes img2img

### DIFF
--- a/docker_images/diffusers/requirements.txt
+++ b/docker_images/diffusers/requirements.txt
@@ -1,9 +1,9 @@
 starlette==0.25.0
 api-inference-community==0.0.30
-huggingface_hub==0.13.3
-safetensors==0.3.0
-diffusers==0.14.0
-transformers==4.27.4
+huggingface_hub==0.14.1
+safetensors==0.3.1
+diffusers==0.16.1
+transformers==4.28.1
 accelerate==0.18.0
 pydantic==1.8.2
 ftfy==6.1.1

--- a/docker_images/diffusers/tests/test_api_image_to_image.py
+++ b/docker_images/diffusers/tests/test_api_image_to_image.py
@@ -45,13 +45,17 @@ class ImageToImageTestCase(TestCase):
 
     def test_simple(self):
         image = PIL.Image.new("RGB", (64, 64))
+        image_bytes = BytesIO()
+        image.save(image_bytes, format="JPEG")
+        image_bytes.seek(0)
+
         parameters = {"prompt": "soap bubble"}
 
         with TestClient(self.app) as client:
             response = client.post(
                 "/",
                 json={
-                    "image": base64.b64encode(image).decode("utf-8"),
+                    "image": base64.b64encode(image_bytes.read()).decode("utf-8"),
                     "parameters": parameters,
                 },
             )
@@ -72,7 +76,8 @@ class ImageToImageTestCase(TestCase):
             response.status_code,
             400,
         )
-        self.assertEqual(
-            response.content,
-            b'{"error":"\'utf-8\' codec can\'t decode byte 0xc3 in position 0: invalid continuation byte"}',
+
+        self.assertTrue(
+            b'{"error":"cannot identify image file <_io.BytesIO object at'
+            in response.content
         )


### PR DESCRIPTION
@patrickvonplaten  Here is a summary:

Defer to the DiffusionPipeline for StableDiffusionImg2ImgPipeline, as AltDiffusionImg2ImgPipeline is currently throwing basic errors when passing **kwargs.

I am explicitly checking the `model_type` using the `config.json` and `model_index.json`, and loading the appropriate pipelines to support Img2Img on `[AltDiffusion, ControlNetModel, StableDiffusion, and InstructPix2Pix]`

All tests `pytest -sv --rootdir docker_images/diffusers docker_images/diffusers` are now passing. 🙌

You can also add extra models for testing locally:

```python
TESTABLE_MODELS: Dict[str, List[str]] = {
    "text-to-image": ["hf-internal-testing/tiny-stable-diffusion-pipe-no-safety"],
    "image-to-image": [
        "hf-internal-testing/tiny-controlnet",
        "hf-internal-testing/tiny-stable-diffusion-pix2pix",
        "radames/stable-diffusion-v1-5-img2img",  # stable diffusion
        "radames/instruct-pix2pix-img2img",  # instruct pix2pix
        "lllyasviel/sd-controlnet-depth",  # controlnet
        "lllyasviel/control_v11f1e_sd15_tile",  # controlnet
        "radames/AltDiffusion-m9-img2img",  # alt diffusion
    ],
}
```
Notes:
* Unfortunately, you cannot directly load `BAAI/AltDiffusion-m9`, `runwayml/stable-diffusion-v1-5`, or `timbrooks/instruct-pix2pix` because their inferred tasks are either `text-to-image` or `None`, which will not work.

* I had to update the [`model_index.json`](https://huggingface.co/hf-internal-testing/tiny-stable-diffusion-pix2pix/blob/main/model_index.json#L2) for `hf-internal-testing/tiny-stable-diffusion-pix2pix` in order to fix another testing error.

I really hope this will close the Image2Image implementation here. 
It's really fun we can have instructPix2Pix working
![image](https://user-images.githubusercontent.com/102277/236590894-86bade10-cf98-4f4c-aba4-bee41580fea8.png)

