### PR TITLE
Add more img2img Pipelines

### DIFF
--- a/docker_images/diffusers/Dockerfile
+++ b/docker_images/diffusers/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Nicolas Patry <nicolas@huggingface.co>"
 # Add any system dependency here
 # RUN apt-get update -y && apt-get install libXXX -y
 
-RUN pip install --no-cache-dir torch==1.13.0 torchvision==0.14.0 torchaudio==0.13.0
+RUN pip install --no-cache-dir torch==2.0.1 torchvision==0.15.2 torchaudio==2.0.2
 COPY ./requirements.txt /app
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/docker_images/diffusers/app/pipelines/image_to_image.py
+++ b/docker_images/diffusers/app/pipelines/image_to_image.py
@@ -1,9 +1,6 @@
 import json
 import os
 
-import jax
-import jax.numpy as jnp
-import numpy as np
 import torch
 from app.pipelines import Pipeline
 from diffusers import (
@@ -12,8 +9,6 @@ from diffusers import (
     ControlNetModel,
     DiffusionPipeline,
     DPMSolverMultistepScheduler,
-    FlaxControlNetModel,
-    FlaxStableDiffusionControlNetPipeline,
     StableDiffusionControlNetPipeline,
     StableDiffusionImageVariationPipeline,
     StableDiffusionImg2ImgPipeline,
@@ -23,8 +18,6 @@ from diffusers import (
     StableUnCLIPPipeline,
 )
 from diffusers.models.attention_processor import AttnProcessor2_0
-from flax.jax_utils import replicate
-from flax.training.common_utils import shard
 from huggingface_hub import hf_hub_download, model_info
 from PIL import Image
 
@@ -76,28 +69,6 @@ class ImageToImagePipeline(Pipeline):
                 use_auth_token=use_auth_token,
                 **kwargs,
             )
-        elif model_type == "FlaxControlNetModel":
-            model_to_load = (
-                model_data.cardData["base_model"]
-                if "base_model" in model_data.cardData
-                else "runwayml/stable-diffusion-v1-5"
-            )
-            controlnet, controlnet_params = FlaxControlNetModel.from_pretrained(
-                model_id, dtype=jnp.bfloat16
-            )
-            (
-                self.ldm,
-                self.params,
-            ) = FlaxStableDiffusionControlNetPipeline.from_pretrained(
-                model_to_load,
-                controlnet=controlnet,
-                revision="flax",
-                use_auth_token=use_auth_token,
-                dtype=jnp.bfloat16,
-            )
-            self.params["controlnet"] = controlnet_params
-            self.p_params = replicate(self.params)
-
         elif model_type in ["AltDiffusionPipeline", "AltDiffusionImg2ImgPipeline"]:
             self.ldm = AltDiffusionImg2ImgPipeline.from_pretrained(
                 model_id, use_auth_token=use_auth_token, **kwargs
@@ -113,14 +84,17 @@ class ImageToImagePipeline(Pipeline):
             self.ldm = StableUnCLIPImg2ImgPipeline.from_pretrained(
                 model_id, use_auth_token=use_auth_token, **kwargs
             )
-        else:
+        elif model_type in [
+            "StableDiffusionImageVariationPipeline",
+            "StableDiffusionInstructPix2PixPipeline",
+        ]:
             self.ldm = DiffusionPipeline.from_pretrained(
                 model_id, use_auth_token=use_auth_token, **kwargs
             )
+        else:
+            raise ValueError("Model type not found or pipeline not implemented")
 
-        if torch.cuda.is_available() and not isinstance(
-            self.ldm, FlaxStableDiffusionControlNetPipeline
-        ):
+        if torch.cuda.is_available():
             self.ldm.to("cuda")
             self.ldm.unet.set_attn_processor(AttnProcessor2_0())
 
@@ -176,35 +150,5 @@ class ImageToImagePipeline(Pipeline):
             # only image is needed
             images = self.ldm(image, **kwargs)["images"]
             return images[0]
-        elif isinstance(self.ldm, FlaxStableDiffusionControlNetPipeline):
-            if "negative_prompt" in kwargs:
-                negative_prompt = kwargs["negative_prompt"]
-                del kwargs["negative_prompt"]
-            else:
-                negative_prompt = ""
-
-            prompt_ids = self.ldm.prepare_text_inputs(prompt)
-            processed_image = self.ldm.prepare_image_inputs(image)
-            negative_prompt_ids = self.ldm.prepare_text_inputs(negative_prompt)
-
-            prompt_ids = shard(prompt_ids)
-            negative_prompt_ids = shard(negative_prompt_ids)
-            processed_image = shard(processed_image)
-            rng = jax.random.PRNGKey(np.random.randint(0, 1000000))
-            rng = jax.random.split(rng, jax.device_count())
-
-            output = self.ldm(
-                prompt_ids=prompt_ids,
-                image=processed_image,
-                params=self.p_params,
-                prng_seed=rng,
-                neg_prompt_ids=negative_prompt_ids,
-                jit=True,
-            ).images
-
-            output = output.reshape((1,) + output.shape[-3:])
-            final_image = [np.array(x * 255, dtype=np.uint8) for x in output]
-
-            return Image.fromarray(final_image[0])
         else:
-            raise ValueError("Model type not found")
+            raise ValueError("Model type not found or pipeline not implemented")

--- a/docker_images/diffusers/app/pipelines/image_to_image.py
+++ b/docker_images/diffusers/app/pipelines/image_to_image.py
@@ -1,16 +1,30 @@
 import json
 import os
 
+import jax
+import jax.numpy as jnp
+import numpy as np
 import torch
 from app.pipelines import Pipeline
 from diffusers import (
     AltDiffusionImg2ImgPipeline,
+    AltDiffusionPipeline,
     ControlNetModel,
+    DiffusionPipeline,
     DPMSolverMultistepScheduler,
+    FlaxControlNetModel,
+    FlaxStableDiffusionControlNetPipeline,
     StableDiffusionControlNetPipeline,
+    StableDiffusionImageVariationPipeline,
     StableDiffusionImg2ImgPipeline,
     StableDiffusionInstructPix2PixPipeline,
+    StableDiffusionPipeline,
+    StableUnCLIPImg2ImgPipeline,
+    StableUnCLIPPipeline,
 )
+from diffusers.models.attention_processor import AttnProcessor2_0
+from flax.jax_utils import replicate
+from flax.training.common_utils import shard
 from huggingface_hub import hf_hub_download, model_info
 from PIL import Image
 
@@ -34,7 +48,6 @@ class ImageToImagePipeline(Pipeline):
             if any(file.rfilename == file_name for file in model_data.siblings):
                 config_file_name = file_name
                 break
-
         if config_file_name:
             config_file = hf_hub_download(
                 model_id, config_file_name, token=use_auth_token
@@ -48,7 +61,12 @@ class ImageToImagePipeline(Pipeline):
 
         # load according to model type
         if model_type == "ControlNetModel":
-            model_to_load = model_data.cardData["base_model"]
+            model_to_load = (
+                model_data.cardData["base_model"]
+                if "base_model" in model_data.cardData
+                else "runwayml/stable-diffusion-v1-5"
+            )
+
             controlnet = ControlNetModel.from_pretrained(
                 model_id, use_auth_token=use_auth_token, **kwargs
             )
@@ -58,34 +76,66 @@ class ImageToImagePipeline(Pipeline):
                 use_auth_token=use_auth_token,
                 **kwargs,
             )
-
-        elif model_type == "StableDiffusionPipeline":
-            self.ldm = StableDiffusionImg2ImgPipeline.from_pretrained(
-                model_id,
-                use_auth_token=use_auth_token,
-                **kwargs,
+        elif model_type == "FlaxControlNetModel":
+            model_to_load = (
+                model_data.cardData["base_model"]
+                if "base_model" in model_data.cardData
+                else "runwayml/stable-diffusion-v1-5"
             )
+            controlnet, controlnet_params = FlaxControlNetModel.from_pretrained(
+                model_id, dtype=jnp.bfloat16
+            )
+            (
+                self.ldm,
+                self.params,
+            ) = FlaxStableDiffusionControlNetPipeline.from_pretrained(
+                model_to_load,
+                controlnet=controlnet,
+                revision="flax",
+                use_auth_token=use_auth_token,
+                dtype=jnp.bfloat16,
+            )
+            self.params["controlnet"] = controlnet_params
+            self.p_params = replicate(self.params)
 
-        elif model_type == "AltDiffusionPipeline":
+        elif model_type in ["AltDiffusionPipeline", "AltDiffusionImg2ImgPipeline"]:
             self.ldm = AltDiffusionImg2ImgPipeline.from_pretrained(
                 model_id, use_auth_token=use_auth_token, **kwargs
             )
-        elif model_type == "StableDiffusionInstructPix2PixPipeline":
-            self.ldm = StableDiffusionInstructPix2PixPipeline.from_pretrained(
+        elif model_type in [
+            "StableDiffusionPipeline",
+            "StableDiffusionImg2ImgPipeline",
+        ]:
+            self.ldm = StableDiffusionImg2ImgPipeline.from_pretrained(
+                model_id, use_auth_token=use_auth_token, **kwargs
+            )
+        elif model_type in ["StableUnCLIPPipeline", "StableUnCLIPImg2ImgPipeline"]:
+            self.ldm = StableUnCLIPImg2ImgPipeline.from_pretrained(
+                model_id, use_auth_token=use_auth_token, **kwargs
+            )
+        else:
+            self.ldm = DiffusionPipeline.from_pretrained(
                 model_id, use_auth_token=use_auth_token, **kwargs
             )
 
-        if torch.cuda.is_available():
+        if torch.cuda.is_available() and not isinstance(
+            self.ldm, FlaxStableDiffusionControlNetPipeline
+        ):
             self.ldm.to("cuda")
-            self.ldm.enable_xformers_memory_efficient_attention()
+            self.ldm.unet.set_attn_processor(AttnProcessor2_0())
 
         if isinstance(
             self.ldm,
             (
+                StableUnCLIPImg2ImgPipeline,
+                StableUnCLIPPipeline,
+                StableDiffusionPipeline,
                 StableDiffusionImg2ImgPipeline,
+                AltDiffusionPipeline,
                 AltDiffusionImg2ImgPipeline,
                 StableDiffusionControlNetPipeline,
                 StableDiffusionInstructPix2PixPipeline,
+                StableDiffusionImageVariationPipeline,
             ),
         ):
             self.ldm.scheduler = DPMSolverMultistepScheduler.from_config(
@@ -102,18 +152,59 @@ class ImageToImagePipeline(Pipeline):
         Return:
             A :obj:`PIL.Image.Image` with the raw image representation as PIL.
         """
+        if "num_inference_steps" not in kwargs:
+            kwargs["num_inference_steps"] = 25
+
         if isinstance(
             self.ldm,
             (
+                StableDiffusionPipeline,
                 StableDiffusionImg2ImgPipeline,
+                AltDiffusionPipeline,
                 AltDiffusionImg2ImgPipeline,
                 StableDiffusionControlNetPipeline,
                 StableDiffusionInstructPix2PixPipeline,
             ),
         ):
-            if "num_inference_steps" not in kwargs:
-                kwargs["num_inference_steps"] = 25
             images = self.ldm(prompt, image, **kwargs)["images"]
             return images[0]
+        elif isinstance(self.ldm, (StableUnCLIPImg2ImgPipeline, StableUnCLIPPipeline)):
+            # image comes first
+            images = self.ldm(image, prompt, **kwargs)["images"]
+            return images[0]
+        elif isinstance(self.ldm, StableDiffusionImageVariationPipeline):
+            # only image is needed
+            images = self.ldm(image, **kwargs)["images"]
+            return images[0]
+        elif isinstance(self.ldm, FlaxStableDiffusionControlNetPipeline):
+            if "negative_prompt" in kwargs:
+                negative_prompt = kwargs["negative_prompt"]
+                del kwargs["negative_prompt"]
+            else:
+                negative_prompt = ""
+
+            prompt_ids = self.ldm.prepare_text_inputs(prompt)
+            processed_image = self.ldm.prepare_image_inputs(image)
+            negative_prompt_ids = self.ldm.prepare_text_inputs(negative_prompt)
+
+            prompt_ids = shard(prompt_ids)
+            negative_prompt_ids = shard(negative_prompt_ids)
+            processed_image = shard(processed_image)
+            rng = jax.random.PRNGKey(np.random.randint(0, 1000000))
+            rng = jax.random.split(rng, jax.device_count())
+
+            output = self.ldm(
+                prompt_ids=prompt_ids,
+                image=processed_image,
+                params=self.p_params,
+                prng_seed=rng,
+                neg_prompt_ids=negative_prompt_ids,
+                jit=True,
+            ).images
+
+            output = output.reshape((1,) + output.shape[-3:])
+            final_image = [np.array(x * 255, dtype=np.uint8) for x in output]
+
+            return Image.fromarray(final_image[0])
         else:
             raise ValueError("Model type not found")

--- a/docker_images/diffusers/app/pipelines/text_to_image.py
+++ b/docker_images/diffusers/app/pipelines/text_to_image.py
@@ -9,6 +9,7 @@ from diffusers import (
     DPMSolverMultistepScheduler,
     StableDiffusionPipeline,
 )
+from diffusers.models.attention_processor import AttnProcessor2_0
 from huggingface_hub import model_info
 
 
@@ -39,8 +40,7 @@ class TextToImagePipeline(Pipeline):
         )
         if torch.cuda.is_available():
             self.ldm.to("cuda")
-            self.ldm.enable_xformers_memory_efficient_attention()
-            self.ldm.unet.to(memory_format=torch.channels_last)
+            self.ldm.unet.set_attn_processor(AttnProcessor2_0())
 
         if is_lora:
             self.ldm.unet.load_attn_procs(

--- a/docker_images/diffusers/requirements.txt
+++ b/docker_images/diffusers/requirements.txt
@@ -3,7 +3,7 @@ api-inference-community==0.0.30
 huggingface_hub==0.14.1
 safetensors==0.3.1
 # diffusers==0.16.1
-git+https://github.com/huggingface/diffusers@main
+git+https://github.com/huggingface/diffusers@909742dbd6873052995dc6cd5f4150ff238015d2
 transformers==4.28.1
 accelerate==0.18.0
 pydantic==1.8.2
@@ -13,7 +13,3 @@ scipy==1.9.3
 torch==2.0.1
 torchvision==0.15.2
 torchaudio==2.0.2
--f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-flax
-jax[cuda11_cudnn82]
-jaxlib

--- a/docker_images/diffusers/requirements.txt
+++ b/docker_images/diffusers/requirements.txt
@@ -2,11 +2,18 @@ starlette==0.25.0
 api-inference-community==0.0.30
 huggingface_hub==0.14.1
 safetensors==0.3.1
-diffusers==0.16.1
+# diffusers==0.16.1
+git+https://github.com/huggingface/diffusers@main
 transformers==4.28.1
 accelerate==0.18.0
 pydantic==1.8.2
 ftfy==6.1.1
 sentencepiece==0.1.97
 scipy==1.9.3
-xformers==0.0.19
+torch==2.0.1
+torchvision==0.15.2
+torchaudio==2.0.2
+-f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+flax
+jax[cuda11_cudnn82]
+jaxlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,9 @@ parameterized>=0.8.1
 pillow>=8.2.0
 huggingface_hub>=0.5.1
 datasets>=2.2
+pytest
+httpx
+uvicorn
+black
+isort
+flake8


### PR DESCRIPTION
This is an attempt to add a few more im2img pipelines.

This PR adds support for `StableDiffusionImageVariationPipeline`, `StableUnCLIPImg2ImgPipeline` and finally `FlaxStableDiffusionControlNetPipeline` 

Two points of concern:
1. I'm using Diffusers 0.17.0.dev0 - git+https://github.com/huggingface/diffusers@main since it has support for the new`FlaxStableDiffusionControlNetPipeline`, and PyTorch 2.0
2. Running Flax/Jax on a GPU container was a bit challenging, I'm not sure if this will be compatible with our API backend, currently to make it work on my test enviroment I needed to use `nvidia/cuda:11.7.1-devel-ubuntu22.04` and `jax[cuda11_cudnn82]` the models take a considerable time to load, then the inference time was reasonable, using `Tesla V100 16VRAM` @Narsil wdyt? 

If the Flax is to complicated I can remove it from this PR. thanks

You can run tests on your env and pick a model and pipeline.

Install requirements, you also need docker/GPU

```pip install -r requirements.txt # for pytests, quality and manager``` 
```pip install -r docker_images/diffusers/requirements.txt # for local pipeline requirements```
Run all tests `pytest -sv --rootdir docker_images/diffusers docker_images/diffusers` 

Run a single model via Docker, then you can send requests
```DEBUG=1 ./manage.py docker "mfidabel/controlnet-segment-anything" --gpu```
or local
```DEBUG=1 ./manage.py start "mfidabel/controlnet-segment-anything" --gpu```
then you can test via https://observablehq.com/d/6ff4df5014d1ed1f

```python
TESTABLE_MODELS: Dict[str, List[str]] = {
    "text-to-image": ["hf-internal-testing/tiny-stable-diffusion-pipe-no-safety"],
    "image-to-image": [
        "hf-internal-testing/tiny-controlnet",
        "hf-internal-testing/tiny-stable-diffusion-pix2pix",
        # "radames/stable-diffusion-v1-5-img2img",  # stable diffusion
        # "radames/instruct-pix2pix-img2img",  # instruct pix2pix
        # "lllyasviel/sd-controlnet-depth",  # controlnet
        # "lllyasviel/control_v11f1e_sd15_tile",  # controlnet
        # "radames/AltDiffusion-m9-img2img",  # alt diffusion
        # "lambdalabs/sd-image-variations-diffusers",  # StableDiffusionImageVariationPipeline
        # "radames/stable-diffusion-2-1-unclip-small-img2img",  # StableDiffusionImg2ImgPipeline
        # # "stabilityai/stable-diffusion-2-1-unclip",  # StableDiffusionImg2ImgPipeline
        # "mfidabel/controlnet-segment-anything",  # flax controlnet
        #”Vincent-luo/controlnet-hands", # flax controlnet
    ],
}
```



 