### PR TITLE
Make LoRA text-to-image compatible with new weights

### DIFF
--- a/docker_images/diffusers/app/pipelines/text_to_image.py
+++ b/docker_images/diffusers/app/pipelines/text_to_image.py
@@ -43,7 +43,7 @@ class TextToImagePipeline(Pipeline):
             self.ldm.unet.to(memory_format=torch.channels_last)
 
         if is_lora:
-            self.ldm.unet.load_attn_procs(
+            self.ldm.load_lora_weights(
                 model_id, use_auth_token=os.getenv("HF_API_TOKEN")
             )
 


### PR DESCRIPTION
Such as the ones in https://huggingface.co/sayakpaul/dreambooth

This should be compatible with diffusers 0.16.1, which is the version pinned in the requirements.
