### PR TITLE
add more img2img

### DIFF
--- a/docker_images/diffusers/app/pipelines/image_to_image.py
+++ b/docker_images/diffusers/app/pipelines/image_to_image.py
@@ -10,10 +10,13 @@ from diffusers import (
     DiffusionPipeline,
     DPMSolverMultistepScheduler,
     StableDiffusionControlNetPipeline,
+    StableDiffusionDepth2ImgPipeline,
     StableDiffusionImageVariationPipeline,
     StableDiffusionImg2ImgPipeline,
     StableDiffusionInstructPix2PixPipeline,
+    StableDiffusionLatentUpscalePipeline,
     StableDiffusionPipeline,
+    StableDiffusionUpscalePipeline,
     StableUnCLIPImg2ImgPipeline,
     StableUnCLIPPipeline,
 )
@@ -87,6 +90,9 @@ class ImageToImagePipeline(Pipeline):
         elif model_type in [
             "StableDiffusionImageVariationPipeline",
             "StableDiffusionInstructPix2PixPipeline",
+            "StableDiffusionUpscalePipeline",
+            "StableDiffusionLatentUpscalePipeline",
+            "StableDiffusionDepth2ImgPipeline",
         ]:
             self.ldm = DiffusionPipeline.from_pretrained(
                 model_id, use_auth_token=use_auth_token, **kwargs
@@ -110,6 +116,7 @@ class ImageToImagePipeline(Pipeline):
                 StableDiffusionControlNetPipeline,
                 StableDiffusionInstructPix2PixPipeline,
                 StableDiffusionImageVariationPipeline,
+                StableDiffusionDepth2ImgPipeline,
             ),
         ):
             self.ldm.scheduler = DPMSolverMultistepScheduler.from_config(
@@ -138,6 +145,9 @@ class ImageToImagePipeline(Pipeline):
                 AltDiffusionImg2ImgPipeline,
                 StableDiffusionControlNetPipeline,
                 StableDiffusionInstructPix2PixPipeline,
+                StableDiffusionUpscalePipeline,
+                StableDiffusionLatentUpscalePipeline,
+                StableDiffusionDepth2ImgPipeline,
             ),
         ):
             images = self.ldm(prompt, image, **kwargs)["images"]


### PR DESCRIPTION
Added
 
* StableDiffusionDepth2ImgPipeline
* StableDiffusionLatentUpscalePipeline
* StableDiffusionUpscalePipeline

@patrickvonplaten is there any other Image2Image Pipeline worth adding? otherwise I think we've covered all the coolest ones 

In case you want to test, I have duplicated models with right `image-to-image` tag

```python 
    "image-to-image": [
        "hf-internal-testing/tiny-controlnet",
        "hf-internal-testing/tiny-stable-diffusion-pix2pix",
        "radames/stable-diffusion-v1-5-img2img",  # stable diffusion
        "radames/AltDiffusion-m9-img2img",  # alt diffusion
        "timbrooks/instruct-pix2pix",  # instruct pix2pix
        "lllyasviel/sd-controlnet-depth",  # controlnet
        "lllyasviel/control_v11f1e_sd15_tile",  # controlnet
        "lambdalabs/sd-image-variations-diffusers",  # StableDiffusionImageVariationPipeline
        "radames/stable-diffusion-2-1-unclip-small-img2img",  # StableDiffusionImg2ImgPipeline
        "radames/stable-diffusion-x4-upscaler-img2img",  # StableDiffusionUpscalePipeline
        "radames/sd-x2-latent-upscaler-img2img",  # StableDiffusionLatentUpscalePipeline
        "radames/stable-diffusion-2-depth-img2img",  # StableDiffusionDepth2ImgPipeline
    ],
```