### PR TITLE
Periodically unload model / reset worker if no request was received for a while

### DIFF
--- a/docker_images/diffusers/app/idle.py
+++ b/docker_images/diffusers/app/idle.py
@@ -1,0 +1,58 @@
+import asyncio
+import contextlib
+import logging
+import os
+import signal
+import time
+
+
+LOG = logging.getLogger(__name__)
+
+LAST_START = None
+LAST_END = None
+
+UNLOAD_IDLE = os.getenv("UNLOAD_IDLE", "").lower() in ('1', 'true')
+IDLE_TIMEOUT = int(os.getenv("IDLE_TIMEOUT", 15))
+
+
+async def live_check_loop():
+    global LAST_START, LAST_END
+
+    pid = os.getpid()
+
+    LOG.debug("Starting live check loop")
+
+    while True:
+        await asyncio.sleep(IDLE_TIMEOUT)
+        LOG.debug("Checking whether we should unload anything from gpu")
+
+        last_start = LAST_START
+        last_end = LAST_END
+
+        LOG.debug("Checking pid %d activity", pid)
+        if not last_start:
+            continue
+        if not last_end or last_start >= last_end:
+            LOG.debug("Request likely being processed for pid %d", pid)
+            continue
+        now = time.time()
+        last_request_age = now - last_end
+        LOG.debug("Pid %d, last request age %s", pid, last_request_age)
+        if last_request_age < IDLE_TIMEOUT:
+            LOG.debug("Model recently active")
+        else:
+            LOG.debug("Inactive for too long. Leaving live check loop")
+            break
+    LOG.debug("Aborting this worker")
+    os.kill(pid, signal.SIGTERM)
+
+
+@contextlib.contextmanager
+def request_witnesses():
+    global LAST_START, LAST_END
+    # Simple assignment, concurrency safe, no need for any lock
+    LAST_START = time.time()
+    try:
+        yield
+    finally:
+        LAST_END = time.time()

--- a/docker_images/diffusers/app/main.py
+++ b/docker_images/diffusers/app/main.py
@@ -1,19 +1,11 @@
-# isort: off
-import logging
-
-if __name__ == "__main__":
-    logging.basicConfig(
-        level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s"
-    )
-    logger = logging.getLogger(__name__)
-else:
-    logger = logging.getLogger(__name__)
-# isort: on
+import asyncio
 import functools
+import logging
 import os
 from typing import Dict, Type
 
 from api_inference_community.routes import pipeline_route, status_ok
+from app import idle
 from app.pipelines import ImageToImagePipeline, Pipeline, TextToImagePipeline
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
@@ -77,12 +69,10 @@ app = Starlette(routes=routes, middleware=middleware)
 
 @app.on_event("startup")
 async def startup_event():
-    logger = logging.getLogger("uvicorn.access")
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
-    logger.handlers = [handler]
-
+    reset_logging()
     # Link between `api-inference-community` and framework code.
+    if idle.UNLOAD_IDLE:
+        asyncio.create_task(idle.live_check_loop(), name="live_check_loop")
     app.get_pipeline = get_pipeline
     try:
         get_pipeline()
@@ -91,7 +81,16 @@ async def startup_event():
         pass
 
 
+def reset_logging():
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        force=True,
+    )
+
+
 if __name__ == "__main__":
+    reset_logging()
     try:
         get_pipeline()
     except Exception:

--- a/docker_images/diffusers/app/timing.py
+++ b/docker_images/diffusers/app/timing.py
@@ -1,0 +1,20 @@
+import logging
+from functools import wraps
+from time import time
+
+
+logger = logging.getLogger(__name__)
+
+
+def timing(f):
+    @wraps(f)
+    def inner(*args, **kwargs):
+        start = time()
+        try:
+            ret = f(*args, **kwargs)
+        finally:
+            end = time()
+            logger.debug("Func: %r took: %.2f sec to execute", f.__name__, end - start)
+        return ret
+
+    return inner


### PR DESCRIPTION
Allows to free gpu resources for example and the cost to move it back to gpu if already loaded in mem is only ~3s. 

Add some overcommit possibility when serving several models on a single gpu at once

tl;dr

The Api Inference infra now serves most diffusion models on shared gpus: thus we can simultaneously serve the very same number of diffusion models as before with twice less hosts dedicated for this. However, we could improve the stacking models on a single gpu by adding some overcommit possibility. This is the point of the pr: releasing the gpu resources when idle, more precisely the gpu memory that is currently the main factor preventing us from increasing the model stacking ratio on a gpu. In this pr the Guvicorn worker is simply killed as soon as we see that the model did not receive any request for a while (but the asgi server respawns one immediately so that's ok). This releases the gpu resources and allows for other models to concurrently serve requests. Meanwhile the model is still loaded in ram+swap, ready to be migrated on gpu in ~2-4 seconds at the next request. WIthout this, some gpu resources stay allocated for this model as long as the asgi worker runs. 