### PR TITLE
add support for Kandinsky

### DIFF
--- a/docker_images/diffusers/app/idle.py
+++ b/docker_images/diffusers/app/idle.py
@@ -11,7 +11,7 @@ LOG = logging.getLogger(__name__)
 LAST_START = None
 LAST_END = None
 
-UNLOAD_IDLE = os.getenv("UNLOAD_IDLE", "").lower() in ('1', 'true')
+UNLOAD_IDLE = os.getenv("UNLOAD_IDLE", "").lower() in ("1", "true")
 IDLE_TIMEOUT = int(os.getenv("IDLE_TIMEOUT", 15))
 
 

--- a/docker_images/diffusers/app/pipelines/image_to_image.py
+++ b/docker_images/diffusers/app/pipelines/image_to_image.py
@@ -23,7 +23,6 @@ from diffusers import (
     StableUnCLIPImg2ImgPipeline,
     StableUnCLIPPipeline,
 )
-from diffusers.models.attention_processor import AttnProcessor2_0
 from huggingface_hub import hf_hub_download, model_info
 from PIL import Image
 
@@ -139,8 +138,6 @@ class ImageToImagePipeline(Pipeline):
             self.ldm.to("cuda")
             if isinstance(self.ldm, (KandinskyImg2ImgPipeline)):
                 self.prior.to("cuda")
-            else:
-                self.ldm.unet.set_attn_processor(AttnProcessor2_0())
 
     def __call__(self, image: Image.Image, prompt: str = "", **kwargs) -> "Image.Image":
         """
@@ -163,6 +160,7 @@ class ImageToImagePipeline(Pipeline):
         return resp
 
     def _process_req(self, image, prompt, **kwargs):
+        # only one image per prompt is supported
         kwargs["num_images_per_prompt"] = 1
         if isinstance(
             self.ldm,

--- a/docker_images/diffusers/app/pipelines/image_to_image.py
+++ b/docker_images/diffusers/app/pipelines/image_to_image.py
@@ -202,13 +202,7 @@ class ImageToImagePipeline(Pipeline):
                 "negative_prompt": kwargs.get("negative_prompt", None),
                 "guidance_scale": kwargs.get("guidance_scale", 7),
             }
-            prior_emb = self.prior(prompt, **prior_args)
-            image_emb = prior_emb.images
-            zero_image_emb = prior_emb.zero_embeds
-            if "negative_prompt" in kwargs:
-                zero_image_emb = self.prior(
-                    kwargs["negative_prompt"], **prior_args
-                ).images
+            image_emb, zero_image_emb = self.prior(prompt, **prior_args).to_tuple()
             images = self.ldm(
                 prompt,
                 image=image,

--- a/docker_images/diffusers/app/pipelines/text_to_image.py
+++ b/docker_images/diffusers/app/pipelines/text_to_image.py
@@ -127,10 +127,6 @@ class TextToImagePipeline(Pipeline):
                 "guidance_scale": kwargs.get("guidance_scale", 4),
             }
             image_emb, zero_image_emb = self.prior(prompt, **prior_args).to_tuple()
-            if "negative_prompt" in kwargs:
-                zero_image_emb = self.prior(
-                    kwargs["negative_prompt"], **prior_args
-                ).images
             images = self.ldm(
                 inputs,
                 image_embeds=image_emb,

--- a/docker_images/diffusers/app/pipelines/text_to_image.py
+++ b/docker_images/diffusers/app/pipelines/text_to_image.py
@@ -14,7 +14,6 @@ from diffusers import (
     KandinskyPriorPipeline,
     StableDiffusionPipeline,
 )
-from diffusers.models.attention_processor import AttnProcessor2_0
 from huggingface_hub import hf_hub_download, model_info
 
 
@@ -92,8 +91,6 @@ class TextToImagePipeline(Pipeline):
             self.ldm.to("cuda")
             if isinstance(self.ldm, (KandinskyPipeline)):
                 self.prior.to("cuda")
-            else:
-                self.ldm.unet.set_attn_processor(AttnProcessor2_0())
 
     def __call__(self, inputs: str, **kwargs) -> "Image.Image":
         """
@@ -112,6 +109,7 @@ class TextToImagePipeline(Pipeline):
         return resp
 
     def _process_req(self, inputs, **kwargs):
+        # only one image per prompt is supported
         kwargs["num_images_per_prompt"] = 1
         if isinstance(self.ldm, (StableDiffusionPipeline, AltDiffusionPipeline)):
             if "num_inference_steps" not in kwargs:

--- a/docker_images/diffusers/app/pipelines/text_to_image.py
+++ b/docker_images/diffusers/app/pipelines/text_to_image.py
@@ -126,7 +126,7 @@ class TextToImagePipeline(Pipeline):
                 "negative_prompt": kwargs.get("negative_prompt", None),
                 "guidance_scale": kwargs.get("guidance_scale", 4),
             }
-            image_emb, zero_image_emb = self.prior(prompt, **prior_args).to_tuple()
+            image_emb, zero_image_emb = self.prior(inputs, **prior_args).to_tuple()
             images = self.ldm(
                 inputs,
                 image_embeds=image_emb,

--- a/docker_images/diffusers/app/pipelines/text_to_image.py
+++ b/docker_images/diffusers/app/pipelines/text_to_image.py
@@ -126,9 +126,7 @@ class TextToImagePipeline(Pipeline):
                 "negative_prompt": kwargs.get("negative_prompt", None),
                 "guidance_scale": kwargs.get("guidance_scale", 4),
             }
-            prior_emb = self.prior(inputs, **prior_args)
-            image_emb = prior_emb.images
-            zero_image_emb = prior_emb.zero_embeds
+            image_emb, zero_image_emb = self.prior(prompt, **prior_args).to_tuple()
             if "negative_prompt" in kwargs:
                 zero_image_emb = self.prior(
                     kwargs["negative_prompt"], **prior_args

--- a/docker_images/diffusers/requirements.txt
+++ b/docker_images/diffusers/requirements.txt
@@ -3,7 +3,7 @@ api-inference-community==0.0.30
 huggingface_hub==0.14.1
 safetensors==0.3.1
 # diffusers==0.16.1
-git+https://github.com/huggingface/diffusers@7d0ac4eeabfe78f5c38ad6582bb1062a43195a74
+git+https://github.com/huggingface/diffusers@4f14b363297cf8deac3e88a3bf31f59880ac8a96
 transformers==4.28.1
 accelerate==0.18.0
 hf_transfer==0.1.3

--- a/docker_images/diffusers/requirements.txt
+++ b/docker_images/diffusers/requirements.txt
@@ -3,7 +3,7 @@ api-inference-community==0.0.30
 huggingface_hub==0.14.1
 safetensors==0.3.1
 # diffusers==0.16.1
-git+https://github.com/huggingface/diffusers@4f14b363297cf8deac3e88a3bf31f59880ac8a96
+git+https://github.com/huggingface/diffusers@0dbdc0cbae466a10df146bf61db489fb447029b3
 transformers==4.28.1
 accelerate==0.18.0
 hf_transfer==0.1.3

--- a/docker_images/diffusers/requirements.txt
+++ b/docker_images/diffusers/requirements.txt
@@ -3,7 +3,7 @@ api-inference-community==0.0.30
 huggingface_hub==0.14.1
 safetensors==0.3.1
 # diffusers==0.16.1
-git+https://github.com/huggingface/diffusers@909742dbd6873052995dc6cd5f4150ff238015d2
+git+https://github.com/huggingface/diffusers@7d0ac4eeabfe78f5c38ad6582bb1062a43195a74
 transformers==4.28.1
 accelerate==0.18.0
 hf_transfer==0.1.3


### PR DESCRIPTION
Notes:
* removed the `AttnProcessor2_0` since it's enabled by default if using PyTorch 2.0 right?
* had to break `kwargs`  for the prior, since it will throw in case user send args, such as `width`, `strength`, etc.
* for each pipeline we can set a default  `num_inference_steps` @yiyixuxu please let me know if 100 for img2img works, since I saw it on your example. `num_images_per_prompt` is always 1


<details>
    <summary> Notes for testing</summary>

You can use these models, and set `api-inference-community/docker_images/diffusers/tests/test_api.py` temporary on your local env

```python
TESTABLE_MODELS: Dict[str, List[str]] = {
    "text-to-image": [
        "hf-internal-testing/tiny-stable-diffusion-pipe-no-safety",
        "kandinsky-community/kandinsky-2-1",
    ],
    "image-to-image": [
        "hf-internal-testing/tiny-controlnet",
        "hf-internal-testing/tiny-stable-diffusion-pix2pix",
        "radames/kandinsky-2-1-img2img",  # kandinsky
    ],
}
```


`pip install -r requirements.txt # for pytests, quality and manager`
`pip install -r docker_images/diffusers/requirements.txt # for local pipeline requirements`
Run all tests 
`pytest -sv --rootdir docker_images/diffusers docker_images/diffusers`

Run a single model via Docker, then you can send requests
`DEBUG=1 ./manage.py docker "kandinsky-community/kandinsky-2-1" --gpu`
or local
`DEBUG=1 ./manage.py start "kandinsky-community/kandinsky-2-1" --gpu`

</details>

