### PR TITLE
fix typo in BERTopic path

### DIFF
--- a/.github/workflows/python-api-bertopic.yaml
+++ b/.github/workflows/python-api-bertopic.yaml
@@ -3,7 +3,7 @@ name: bertopic-docker
 on:
   pull_request:
     paths:
-      - "docker_images/berttopic/**"
+      - "docker_images/bertopic/**"
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes a typo in the naming of bertopic. Failing tests related to a different file (can open a seperate PR to fix that) 