### PR TITLE
feat: added mime accept headers

### DIFF
--- a/api_inference_community/routes.py
+++ b/api_inference_community/routes.py
@@ -11,6 +11,7 @@ from api_inference_community.validation import (
     IMAGE_INPUTS,
     ffmpeg_convert,
     normalize_payload,
+    check_mime_types
 )
 from pydantic import ValidationError
 from starlette.requests import Request
@@ -50,7 +51,7 @@ async def pipeline_route(request: Request) -> Response:
 
     # Parse accept header and determine the appropriate format
     mime = MimeTypes()
-    mimetypes = [x for x in accept.split(',') if mime.file_ext(x)]
+    mimetypes = check_mime_types([x for x in accept.split(',') if mime.file_ext(x)])
 
     return call_pipe(pipe, inputs, params, start, mimetypes)
 

--- a/api_inference_community/routes.py
+++ b/api_inference_community/routes.py
@@ -35,7 +35,7 @@ async def pipeline_route(request: Request) -> Response:
             sampling_rate = pipe.sampling_rate
         except Exception:
             sampling_rate = None
-        inputs, params = normalize_payload(payload, task, sampling_rate=sampling_rate)
+        inputs, params = normalize_payload(payload, task, sampling_rate=sampling_rate, accept_headers=request.headers["accept"])
     except ValidationError as e:
         errors = []
         for error in e.errors():

--- a/api_inference_community/routes.py
+++ b/api_inference_community/routes.py
@@ -108,7 +108,7 @@ def call_pipe(pipe: Any, inputs, params: Dict, start: float, mime_types: Dict[st
             content_type, ext = list(mime_types.items())[0] if mime_types else ("audio/flac", "flac")
             format_for_conversion = ext.lstrip(".")
 
-            data = ffmpeg_convert(waveform, format_for_conversion, sampling_rate)
+            data = ffmpeg_convert(waveform, sampling_rate, format_for_conversion)
             headers["content-type"] = content_type
             return Response(data, headers=headers, status_code=status_code)
         elif task == "audio-to-audio":
@@ -121,7 +121,7 @@ def call_pipe(pipe: Any, inputs, params: Dict, start: float, mime_types: Dict[st
             format_for_conversion = ext.lstrip(".")
 
             for waveform, label in zip(waveforms, labels):
-                data = ffmpeg_convert(waveform, format_for_conversion, sampling_rate)
+                data = ffmpeg_convert(waveform, sampling_rate, format_for_conversion)
                 items.append(
                     {
                         "label": label,

--- a/api_inference_community/routes.py
+++ b/api_inference_community/routes.py
@@ -36,11 +36,11 @@ async def pipeline_route(request: Request) -> Response:
         pipe = request.app.get_pipeline()
     try:
         pipe = request.app.get_pipeline()
-        check_mime_types(mime_types)
         try:
             sampling_rate = pipe.sampling_rate
         except Exception:
             sampling_rate = None
+        check_mime_types(mime_types)
         inputs, params = normalize_payload(payload, task, sampling_rate=sampling_rate)
     except ValidationError as e:
         errors = []

--- a/api_inference_community/routes.py
+++ b/api_inference_community/routes.py
@@ -27,7 +27,6 @@ async def pipeline_route(request: Request) -> Response:
     start = time.time()
     payload = await request.body()
     task = os.environ["TASK"]
-    mime_types = None
     if os.getenv("DEBUG", "0") in {"1", "true"}:
         pipe = request.app.get_pipeline()
     try:

--- a/api_inference_community/routes.py
+++ b/api_inference_community/routes.py
@@ -29,7 +29,7 @@ async def pipeline_route(request: Request) -> Response:
     payload = await request.body()
     task = os.environ["TASK"]
     accept = request.headers["accept"]
-    # Parse accept header and determine the appropriate format
+    # Parse accept header and determine the appropriate response format
     mime = MimeTypes()
     mime_types = [x for x in accept.split(',') if mime.file_ext(x)]
     if os.getenv("DEBUG", "0") in {"1", "true"}:

--- a/api_inference_community/routes.py
+++ b/api_inference_community/routes.py
@@ -119,15 +119,16 @@ def call_pipe(pipe: Any, inputs, params: Dict, start: float) -> Response:
                 )
             return JSONResponse(items, headers=headers, status_code=status_code)
         elif task in {"text-to-image", "image-to-image"}:
-            buf = io.BytesIO()
-            outputs.save(buf, format="JPEG")
-            buf.seek(0)
-            img_bytes = buf.read()
+            image, image_format = outputs
+            buffer = io.BytesIO()
+            image.save(buffer, format=image_format.upper())
+            buffer.seek(0)
+            img_bytes = buffer.read()
             return Response(
                 img_bytes,
                 headers=headers,
                 status_code=200,
-                media_type="image/jpeg",
+                media_type=f"image/{image_format}",
             )
 
     return JSONResponse(

--- a/api_inference_community/routes.py
+++ b/api_inference_community/routes.py
@@ -4,7 +4,6 @@ import logging
 import os
 import time
 from typing import Any, Dict
-from mimetypes import MimeTypes
 
 from api_inference_community.validation import (
     AUDIO_INPUTS,
@@ -35,7 +34,7 @@ async def pipeline_route(request: Request) -> Response:
             sampling_rate = pipe.sampling_rate
         except Exception:
             sampling_rate = None
-        inputs, params = normalize_payload(payload, task, sampling_rate=sampling_rate, accept_headers=request.headers["accept"])
+        inputs, params = normalize_payload(payload, task, sampling_rate=sampling_rate, accept_header=request.headers["accept"])
     except ValidationError as e:
         errors = []
         for error in e.errors():

--- a/api_inference_community/routes.py
+++ b/api_inference_community/routes.py
@@ -6,14 +6,14 @@ import time
 from typing import Any, Dict
 
 from api_inference_community.validation import (
+    AUDIO,
     AUDIO_INPUTS,
+    IMAGE,
     IMAGE_INPUTS,
     IMAGE_OUTPUTS,
-    parse_accept,
-    AUDIO,
-    IMAGE,
     ffmpeg_convert,
     normalize_payload,
+    parse_accept,
 )
 from pydantic import ValidationError
 from starlette.requests import Request

--- a/api_inference_community/routes.py
+++ b/api_inference_community/routes.py
@@ -37,7 +37,7 @@ async def pipeline_route(request: Request) -> Response:
             sampling_rate = pipe.sampling_rate
         except Exception:
             sampling_rate = None
-        mime_types= validate_mime_types(request.headers["accept"])
+        mime_types = validate_mime_types(request.headers["accept"])
         inputs, params = normalize_payload(payload, task, sampling_rate=sampling_rate)
     except ValidationError as e:
         errors = []

--- a/api_inference_community/routes.py
+++ b/api_inference_community/routes.py
@@ -15,6 +15,7 @@ from pydantic import ValidationError
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
+
 HF_HEADER_COMPUTE_TIME = "x-compute-time"
 HF_HEADER_COMPUTE_TYPE = "x-compute-type"
 COMPUTE_TYPE = os.getenv("COMPUTE_TYPE", "cpu")

--- a/api_inference_community/routes.py
+++ b/api_inference_community/routes.py
@@ -51,12 +51,13 @@ async def pipeline_route(request: Request) -> Response:
 
     # Parse accept header and determine the appropriate format
     mime = MimeTypes()
-    mimetypes = check_mime_types([x for x in accept.split(',') if mime.file_ext(x)])
+    mime_types = [x for x in accept.split(',') if mime.file_ext(x)]
+    check_mime_types(mime_types)
 
-    return call_pipe(pipe, inputs, params, start, mimetypes)
+    return call_pipe(pipe, inputs, params, start, mime_types)
 
 
-def call_pipe(pipe: Any, inputs, params: Dict, start: float, mimetypes: list) -> Response:
+def call_pipe(pipe: Any, inputs, params: Dict, start: float, mime_types: list) -> Response:
     root_logger = logging.getLogger()
     warnings = set()
 
@@ -109,7 +110,7 @@ def call_pipe(pipe: Any, inputs, params: Dict, start: float, mimetypes: list) ->
             waveform, sampling_rate = outputs
 
             # Use the first valid mime type for the conversion format or "flac" as default
-            ext = mimetypes[0] if mimetypes else "flac"
+            ext = mime_types[0] if mime_types else "flac"
             format_for_conversion = ext[1:] if ext else "flac"
             data = ffmpeg_convert(waveform, format_for_conversion, sampling_rate)
             headers["content-type"] = f'audio/{format_for_conversion}'
@@ -120,7 +121,7 @@ def call_pipe(pipe: Any, inputs, params: Dict, start: float, mimetypes: list) ->
             headers["content-type"] = "application/json"
 
             # Use the first valid mime type for the conversion format or "flac" as default
-            ext = mimetypes[0] if mimetypes else "flac"
+            ext = mime_types[0] if mime_types else "flac"
             format_for_conversion = ext[1:] if ext else "flac"
 
             for waveform, label in zip(waveforms, labels):

--- a/api_inference_community/routes.py
+++ b/api_inference_community/routes.py
@@ -10,7 +10,7 @@ from api_inference_community.validation import (
     AUDIO_INPUTS,
     IMAGE_INPUTS,
     ffmpeg_convert,
-    normalize_payload
+    normalize_payload,
 )
 from pydantic import ValidationError
 from starlette.requests import Request

--- a/api_inference_community/validation.py
+++ b/api_inference_community/validation.py
@@ -259,6 +259,7 @@ WHITELISTED_AUDIO_MIME_TYPES = {
     "audio/webm": "webm",
 }
 
+
 WHITELISTED_IMAGE_MIME_TYPES = {
     "image/jpeg": "jpg",
     "image/png": "png",

--- a/api_inference_community/validation.py
+++ b/api_inference_community/validation.py
@@ -212,46 +212,6 @@ def check_inputs(inputs, tag):
         raise ValueError(f"{tag} is not a valid pipeline.")
 
 
-MIME_TYPES = {
-    "application/json",
-    "text/csv",
-    "text/plain",
-    "image/png",
-    "image/jpeg",
-    "image/jpg",
-    "image/tiff",
-    "image/bmp",
-    "image/gif",
-    "image/webp",
-    "image/x-image",
-    "audio/x-flac",
-    "audio/flac",
-    "audio/mpeg",
-    "audio/x-mpeg-3",
-    "audio/wave",
-    "audio/wav",
-    "audio/x-wav",
-    "audio/ogg",
-    "audio/x-audio",
-    "audio/webm;codecs=opus"
-    "audio/AMR",
-    "audio/amr",
-    "audio/AMR-WB",
-    "audio/AMR-WB+",
-    "audio/m4a",
-    "audio/x-m4a"
-}
-
-
-def validate_mime_types(accept_header: Any) -> Dict[str, str]:
-    mime = MimeTypes()
-    mime_dict = {mime_type: mime.guess_extension(mime_type) for mime_type in accept_header.split(',')}
-    for mime_type in mime_dict:
-        if mime_type not in MIME_TYPES:
-            raise ValueError(f"{mime_type} is not a supported MIME type.")
-    return mime_dict
-
-
 AUDIO_INPUTS = {
     "automatic-speech-recognition",
     "audio-to-audio",

--- a/api_inference_community/validation.py
+++ b/api_inference_community/validation.py
@@ -266,7 +266,7 @@ WHITELISTED_MIME_TYPES = {
 
 
 def normalize_payload(
-    bpayload: bytes, task: str, sampling_rate: Optional[int] = None, accept_header: Optional[Any] = None
+    bpayload: bytes, task: str, sampling_rate: Optional[int] = None, accept_header: Optional[str] = None
 ) -> Tuple[Any, Dict]:
 
     if accept_header:

--- a/api_inference_community/validation.py
+++ b/api_inference_community/validation.py
@@ -309,7 +309,7 @@ def normalize_payload(
         )
 
 
-def ffmpeg_convert(array: np.array, format_for_conversion: str, sampling_rate: int) -> bytes:
+def ffmpeg_convert(array: np.array, sampling_rate: int, format_for_conversion: str) -> bytes:
     """
     Helper function to convert raw waveforms to actual compressed file (lossless compression here)
     """

--- a/api_inference_community/validation.py
+++ b/api_inference_community/validation.py
@@ -264,13 +264,12 @@ def normalize_payload(
         )
 
 
-def ffmpeg_convert(array: np.array, sampling_rate: int) -> bytes:
+def ffmpeg_convert(array: np.array, format_for_conversion: str, sampling_rate: int) -> bytes:
     """
     Helper function to convert raw waveforms to actual compressed file (lossless compression here)
     """
     ar = str(sampling_rate)
     ac = "1"
-    format_for_conversion = "flac"
     ffmpeg_command = [
         "ffmpeg",
         "-ac",

--- a/api_inference_community/validation.py
+++ b/api_inference_community/validation.py
@@ -164,9 +164,6 @@ class StringInput(BaseModel):
     __root__: str
 
 
-BATCH_ENABLED_PIPELINES = ["feature-extraction"]
-
-
 PARAMS_MAPPING = {
     "conversational": SharedGenerationParams,
     "fill-mask": FillMaskParamsCheck,
@@ -175,12 +172,6 @@ PARAMS_MAPPING = {
     "summarization": SummarizationParamsCheck,
     "zero-shot-classification": ZeroShotParamsCheck,
 }
-
-
-def check_params(params, tag):
-    if tag in PARAMS_MAPPING:
-        PARAMS_MAPPING[tag].parse_obj(params)
-    return True
 
 
 INPUTS_MAPPING = {
@@ -202,6 +193,15 @@ INPUTS_MAPPING = {
     "text-to-speech": StringInput,
     "text-to-image": StringInput,
 }
+
+
+BATCH_ENABLED_PIPELINES = ["feature-extraction"]
+
+
+def check_params(params, tag):
+    if tag in PARAMS_MAPPING:
+        PARAMS_MAPPING[tag].parse_obj(params)
+    return True
 
 
 def check_inputs(inputs, tag):

--- a/api_inference_community/validation.py
+++ b/api_inference_community/validation.py
@@ -255,6 +255,9 @@ WHITELISTED_MIME_TYPES = {
     "audio/mpeg": "mp3",
     "audio/wav": "wav",
     "audio/ogg": "ogg",
+    "audio/mp4": "m4a",
+    "audio/aac": "aac",
+    "audio/webm": "webm",
 }
 
 

--- a/api_inference_community/validation.py
+++ b/api_inference_community/validation.py
@@ -249,7 +249,7 @@ TEXT_INPUTS = {
 }
 
 
-WHITELISTED_MIME_TYPES = {
+WHITELISTED_AUDIO_MIME_TYPES = {
     "audio/flac": "flac",
     "audio/mpeg": "mp3",
     "audio/wav": "wav",
@@ -257,6 +257,9 @@ WHITELISTED_MIME_TYPES = {
     "audio/mp4": "m4a",
     "audio/aac": "aac",
     "audio/webm": "webm",
+}
+
+WHITELISTED_IMAGE_MIME_TYPES = {
     "image/jpeg": "jpg",
     "image/png": "png",
     "image/bmp": "bmp",
@@ -284,7 +287,7 @@ def normalize_payload(
         audio_format = "flac"
 
         for requested_format in requested_formats.values():
-            if requested_format in WHITELISTED_MIME_TYPES.values():
+            if requested_format in WHITELISTED_AUDIO_MIME_TYPES.values():
                 audio_format = requested_format
                 break
 
@@ -294,7 +297,7 @@ def normalize_payload(
         image_format = "jpeg"
 
         for requested_format in requested_formats.values():
-            if requested_format in WHITELISTED_MIME_TYPES.values():
+            if requested_format in WHITELISTED_IMAGE_MIME_TYPES.values():
                 image_format = requested_format
                 break
 
@@ -402,7 +405,7 @@ DATA_PREFIX = os.getenv("HF_TRANSFORMERS_CACHE", "")
 
 def normalize_payload_audio(bpayload: bytes, sampling_rate: int) -> Tuple[Any, Dict]:
     audio_extensions = {
-        f".{ext}" for mime_type, ext in WHITELISTED_MIME_TYPES.items() if "audio" in mime_type
+        f".{ext}" for mime_type, ext in WHITELISTED_AUDIO_MIME_TYPES.items() if "audio" in mime_type
     }
 
     if os.path.isfile(bpayload) and bpayload.startswith(DATA_PREFIX.encode("utf-8")):

--- a/api_inference_community/validation.py
+++ b/api_inference_community/validation.py
@@ -242,7 +242,7 @@ MIME_TYPES = {
 }
 
 
-def check_mime_types(mime_types: List[str]):
+def check_mime_types(mime_types: Dict[str, str]):
     for mime_type in mime_types:
         if mime_type not in MIME_TYPES:
             raise ValueError(f"{mime_type} is not a supported MIME type.")

--- a/api_inference_community/validation.py
+++ b/api_inference_community/validation.py
@@ -399,7 +399,15 @@ def normalize_payload_image(bpayload: bytes) -> Tuple[Any, Dict]:
     return img, {}
 
 
-AUDIO_EXTENSIONS = {".mp3", ".wav", ".flac", ".mp4", ".webm", ".aac"}
+AUDIO_EXTENSIONS = {
+    ".mp3",
+    ".wav",
+    ".flac",
+    ".mp4",
+    ".webm",
+    ".aac",
+    ".ogg"
+}
 
 
 DATA_PREFIX = os.getenv("HF_TRANSFORMERS_CACHE", "")

--- a/api_inference_community/validation.py
+++ b/api_inference_community/validation.py
@@ -165,6 +165,7 @@ class StringInput(BaseModel):
 
 BATCH_ENABLED_PIPELINES = ["feature-extraction"]
 
+
 PARAMS_MAPPING = {
     "conversational": SharedGenerationParams,
     "fill-mask": FillMaskParamsCheck,
@@ -174,10 +175,12 @@ PARAMS_MAPPING = {
     "zero-shot-classification": ZeroShotParamsCheck,
 }
 
+
 def check_params(params, tag):
     if tag in PARAMS_MAPPING:
         PARAMS_MAPPING[tag].parse_obj(params)
     return True
+
 
 INPUTS_MAPPING = {
     "conversational": ConversationalInputsCheck,
@@ -199,12 +202,14 @@ INPUTS_MAPPING = {
     "text-to-image": StringInput,
 }
 
+
 def check_inputs(inputs, tag):
     if tag in INPUTS_MAPPING:
         INPUTS_MAPPING[tag].parse_obj(inputs)
         return True
     else:
         raise ValueError(f"{tag} is not a valid pipeline.")
+
 
 MIME_TYPES = {
     "application/json",
@@ -236,10 +241,12 @@ MIME_TYPES = {
     "audio/x-m4a"
 }
 
+
 def check_mime_types(mime_types: List[str]):
     for mime_type in mime_types:
         if mime_type not in MIME_TYPES:
             raise ValueError(f"{mime_type} is not a supported MIME type.")
+
 
 AUDIO_INPUTS = {
     "automatic-speech-recognition",
@@ -247,6 +254,7 @@ AUDIO_INPUTS = {
     "speech-segmentation",
     "audio-classification",
 }
+
 
 IMAGE_INPUTS = {
     "image-classification",
@@ -256,6 +264,7 @@ IMAGE_INPUTS = {
     "object-detection",
     "zero-shot-image-classification",
 }
+
 
 TEXT_INPUTS = {
     "conversational",

--- a/api_inference_community/validation.py
+++ b/api_inference_community/validation.py
@@ -248,9 +248,22 @@ TEXT_INPUTS = {
     "zero-shot-classification",
 }
 
+MIME_TYPES = {
+    #"image/png",
+    #"image/jpeg",
+    #"image/jpg",
+    #"image/tiff",
+    #"image/bmp",
+    #"image/gif",
+    #"image/webp",
+    "audio/flac",
+    "audio/mpeg",
+    "audio/wav",
+    "audio/ogg",
+}
 
 def normalize_payload(
-    bpayload: bytes, task: str, sampling_rate: Optional[int] = None, accept_headers: Optional[Any] = None
+    bpayload: bytes, task: str, sampling_rate: Optional[int] = None, accept_header: Optional[Any] = None
 ) -> Tuple[Any, Dict]:
     # TODO do something with accept_headers
     if task in AUDIO_INPUTS:

--- a/api_inference_community/validation.py
+++ b/api_inference_community/validation.py
@@ -250,8 +250,9 @@ TEXT_INPUTS = {
 
 
 def normalize_payload(
-    bpayload: bytes, task: str, sampling_rate: Optional[int] = None
+    bpayload: bytes, task: str, sampling_rate: Optional[int] = None, accept_headers: Optional[Any] = None
 ) -> Tuple[Any, Dict]:
+    # TODO do something with accept_headers
     if task in AUDIO_INPUTS:
         if sampling_rate is None:
             raise EnvironmentError(

--- a/api_inference_community/validation.py
+++ b/api_inference_community/validation.py
@@ -163,6 +163,8 @@ class StringInput(BaseModel):
     __root__: str
 
 
+BATCH_ENABLED_PIPELINES = ["feature-extraction"]
+
 PARAMS_MAPPING = {
     "conversational": SharedGenerationParams,
     "fill-mask": FillMaskParamsCheck,
@@ -171,6 +173,11 @@ PARAMS_MAPPING = {
     "summarization": SummarizationParamsCheck,
     "zero-shot-classification": ZeroShotParamsCheck,
 }
+
+def check_params(params, tag):
+    if tag in PARAMS_MAPPING:
+        PARAMS_MAPPING[tag].parse_obj(params)
+    return True
 
 INPUTS_MAPPING = {
     "conversational": ConversationalInputsCheck,
@@ -192,15 +199,6 @@ INPUTS_MAPPING = {
     "text-to-image": StringInput,
 }
 
-BATCH_ENABLED_PIPELINES = ["feature-extraction"]
-
-
-def check_params(params, tag):
-    if tag in PARAMS_MAPPING:
-        PARAMS_MAPPING[tag].parse_obj(params)
-    return True
-
-
 def check_inputs(inputs, tag):
     if tag in INPUTS_MAPPING:
         INPUTS_MAPPING[tag].parse_obj(inputs)
@@ -208,6 +206,40 @@ def check_inputs(inputs, tag):
     else:
         raise ValueError(f"{tag} is not a valid pipeline.")
 
+MIME_TYPES = {
+    "application/json",
+    "text/csv",
+    "text/plain",
+    "image/png",
+    "image/jpeg",
+    "image/jpg",
+    "image/tiff",
+    "image/bmp",
+    "image/gif",
+    "image/webp",
+    "image/x-image",
+    "audio/x-flac",
+    "audio/flac",
+    "audio/mpeg",
+    "audio/x-mpeg-3",
+    "audio/wave",
+    "audio/wav",
+    "audio/x-wav",
+    "audio/ogg",
+    "audio/x-audio",
+    "audio/webm;codecs=opus"
+    "audio/AMR",
+    "audio/amr",
+    "audio/AMR-WB",
+    "audio/AMR-WB+",
+    "audio/m4a",
+    "audio/x-m4a"
+}
+
+def check_mime_types(mime_types: List[str]):
+    for mime_type in mime_types:
+        if mime_type not in MIME_TYPES:
+            raise ValueError(f"{mime_type} is not a supported MIME type.")
 
 AUDIO_INPUTS = {
     "automatic-speech-recognition",

--- a/api_inference_community/validation.py
+++ b/api_inference_community/validation.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 from base64 import b64decode
 from io import BytesIO
+from mimetypes import MimeTypes
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -242,10 +243,13 @@ MIME_TYPES = {
 }
 
 
-def check_mime_types(mime_types: Dict[str, str]):
-    for mime_type in mime_types:
+def validate_mime_types(accept_header: Any) -> Dict[str, str]:
+    mime = MimeTypes()
+    mime_dict = {mime_type: mime.guess_extension(mime_type) for mime_type in accept_header.split(',')}
+    for mime_type in mime_dict:
         if mime_type not in MIME_TYPES:
             raise ValueError(f"{mime_type} is not a supported MIME type.")
+    return mime_dict
 
 
 AUDIO_INPUTS = {

--- a/api_inference_community/validation.py
+++ b/api_inference_community/validation.py
@@ -297,23 +297,15 @@ def normalize_payload(
             raise EnvironmentError(
                 "We cannot normalize audio file if we don't know the sampling rate"
             )
-        inputs, params = normalize_payload_audio(bpayload, sampling_rate)
+        return normalize_payload_audio(bpayload, sampling_rate)
     elif task in IMAGE_INPUTS:
-        inputs, params = normalize_payload_image(bpayload)
+        return normalize_payload_image(bpayload)
     elif task in TEXT_INPUTS:
-        inputs, params = normalize_payload_nlp(bpayload, task)
+        return normalize_payload_nlp(bpayload, task)
     else:
         raise EnvironmentError(
             f"The task `{task}` is not recognized by api-inference-community"
         )
-    # if task in AUDIO_OUTPUTS:
-    #     audio_format = parse_accept(accept, AUDIO)
-    #     params["audio_format"] = audio_format
-    # elif task in IMAGE_OUTPUTS:
-    #     image_format = parse_accept(accept, IMAGE)
-    #     params["image_format"] = image_format
-
-    return inputs, params
 
 
 def ffmpeg_convert(

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -49,7 +49,19 @@ class ValidationTestCase(TestCase):
         waveform, params = normalize_payload_audio(bpayload, sampling_rate)
         self.assertEqual(waveform.shape, (219040,))
 
-        out = ffmpeg_convert(waveform, sampling_rate)
+        out = ffmpeg_convert(waveform, sampling_rate, "flac")
+        self.assertEqual(len(out), 280204)
+        waveform2, params = normalize_payload_audio(out, sampling_rate)
+        self.assertEqual(waveform2.shape, (219040,))
+
+    def test_ffmpeg_convert_wav(self):
+        bpayload = self.read("sample1.flac")
+        sampling_rate = 16000
+        self.assertEqual(len(bpayload), 282378)
+        waveform, params = normalize_payload_audio(bpayload, sampling_rate)
+        self.assertEqual(waveform.shape, (219040,))
+
+        out = ffmpeg_convert(waveform, sampling_rate, "wav")
         self.assertEqual(len(out), 280204)
         waveform2, params = normalize_payload_audio(out, sampling_rate)
         self.assertEqual(waveform2.shape, (219040,))
@@ -61,7 +73,7 @@ class ValidationTestCase(TestCase):
         waveform, params = normalize_payload_audio(bpayload, sampling_rate)
         self.assertEqual(waveform.shape, (109520,))
 
-        out = ffmpeg_convert(waveform, sampling_rate)
+        out = ffmpeg_convert(waveform, sampling_rate, "flac")
         self.assertEqual(len(out), 258996)
         waveform2, params = normalize_payload_audio(out, sampling_rate)
         self.assertEqual(waveform2.shape, (109520,))

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -62,7 +62,7 @@ class ValidationTestCase(TestCase):
         self.assertEqual(waveform.shape, (219040,))
 
         out = ffmpeg_convert(waveform, sampling_rate, "wav")
-        self.assertEqual(len(out), 280204)
+        self.assertEqual(len(out), 438158)
         waveform2, params = normalize_payload_audio(out, sampling_rate)
         self.assertEqual(waveform2.shape, (219040,))
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -188,7 +188,7 @@ class ValidationTestCase(TestCase):
                 pass
 
             def __call__(self, input_: str):
-                return np.array([0, 0, 0]), 16000, "wav"
+                return np.array([0, 0, 0]), 16000
 
         def get_pipeline():
             return Pipeline()
@@ -228,7 +228,7 @@ class ValidationTestCase(TestCase):
                 pass
 
             def __call__(self, input_: str):
-                return np.array([0, 0, 0]), 16000, "ogg"
+                return np.array([0, 0, 0]), 16000
 
         def get_pipeline():
             return Pipeline()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -363,10 +363,9 @@ class ValidationTestCase(TestCase):
                 pass
 
             def __call__(self, input_: str):
-                dirname = os.path.dirname(os.path.abspath(__file__))
-                filename = os.path.join(dirname, "samples", "plane.jpg")
-                returned_image = Image.open(filename)
-                return returned_image
+                image = Image.open(io.BytesIO(input_))
+                image_format = image.format
+                return image, image_format
 
         def get_pipeline():
             return Pipeline()
@@ -410,10 +409,9 @@ class ValidationTestCase(TestCase):
                 pass
 
             def __call__(self, input_: str):
-                dirname = os.path.dirname(os.path.abspath(__file__))
-                filename = os.path.join(dirname, "samples", "plane.jpg")
-                returned_image = Image.open(filename)
-                return returned_image
+                image = Image.open(io.BytesIO(input_))
+                image_format = image.format
+                return image, image_format
 
         def get_pipeline():
             return Pipeline()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -180,6 +180,87 @@ class ValidationTestCase(TestCase):
         )
         self.assertEqual(response.headers["content-type"], "audio/flac")
 
+    def test_tts_pipeline_wav(self):
+        os.environ["TASK"] = "text-to-speech"
+
+        class Pipeline:
+            def __init__(self):
+                pass
+
+            def __call__(self, input_: str):
+                return np.array([0, 0, 0]), 16000, "wav"
+
+        def get_pipeline():
+            return Pipeline()
+
+        routes = [
+            Route("/{whatever:path}", status_ok),
+            Route("/{whatever:path}", pipeline_route, methods=["POST"]),
+        ]
+
+        app = Starlette(routes=routes)
+
+        @app.on_event("startup")
+        async def startup_event():
+            logger = logging.getLogger("uvicorn.access")
+            handler = logging.StreamHandler()
+            handler.setFormatter(
+                logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+            )
+            logger.handlers = [handler]
+
+            app.get_pipeline = get_pipeline
+
+        with TestClient(app) as client:
+            response = client.post("/", data=b"2222", headers={"accept": "audio/wav"})
+
+        self.assertEqual(
+            response.status_code,
+            200,
+        )
+        self.assertEqual(response.headers["content-type"], "audio/wav")
+
+    def test_tts_pipeline_ogg(self):
+        os.environ["TASK"] = "text-to-speech"
+
+        class Pipeline:
+            def __init__(self):
+                pass
+
+            def __call__(self, input_: str):
+                return np.array([0, 0, 0]), 16000, "ogg"
+
+        def get_pipeline():
+            return Pipeline()
+
+        routes = [
+            Route("/{whatever:path}", status_ok),
+            Route("/{whatever:path}", pipeline_route, methods=["POST"]),
+        ]
+
+        app = Starlette(routes=routes)
+
+        @app.on_event("startup")
+        async def startup_event():
+            logger = logging.getLogger("uvicorn.access")
+            handler = logging.StreamHandler()
+            handler.setFormatter(
+                logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+            )
+            logger.handlers = [handler]
+
+            app.get_pipeline = get_pipeline
+
+        with TestClient(app) as client:
+            response = client.post("/", data=b"2222", headers={"accept": "audio/ogg"})
+
+        self.assertEqual(
+            response.status_code,
+            200,
+        )
+        self.assertEqual(response.headers["content-type"], "audio/ogg")
+
+
     def test_audio_to_audio_pipeline(self):
         os.environ["TASK"] = "audio-to-audio"
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -400,6 +400,7 @@ class ValidationTestCase(TestCase):
             200,
         )
         self.assertTrue(isinstance(image, Image.Image))
+        self.assertEqual(response.headers["content-type"], "image/jpeg")
 
     def test_pipeline_zero_shot(self):
         os.environ["TASK"] = "text-classification"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -260,7 +260,6 @@ class ValidationTestCase(TestCase):
         )
         self.assertEqual(response.headers["content-type"], "audio/ogg")
 
-
     def test_audio_to_audio_pipeline(self):
         os.environ["TASK"] = "audio-to-audio"
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -363,9 +363,10 @@ class ValidationTestCase(TestCase):
                 pass
 
             def __call__(self, input_: str):
-                image = Image.open(io.BytesIO(input_))
-                image_format = image.format
-                return image, image_format
+                dirname = os.path.dirname(os.path.abspath(__file__))
+                filename = os.path.join(dirname, "samples", "plane.jpg")
+                returned_image = Image.open(filename)
+                return returned_image
 
         def get_pipeline():
             return Pipeline()
@@ -409,9 +410,10 @@ class ValidationTestCase(TestCase):
                 pass
 
             def __call__(self, input_: str):
-                image = Image.open(io.BytesIO(input_))
-                image_format = image.format
-                return image, image_format
+                dirname = os.path.dirname(os.path.abspath(__file__))
+                filename = os.path.join(dirname, "samples", "plane.jpg")
+                returned_image = Image.open(filename)
+                return returned_image
 
         def get_pipeline():
             return Pipeline()


### PR DESCRIPTION
This ensures that returned payload is in the format that a client can accept.

- Added way to specify accept header mime types for returned image and audio content in the specified format
- Added unit tests for text-to-speech, audio-to-audio, and text-to-image tasks