### PR TITLE
add SpeechBrain Speech-Emotion-Diarization interface

### DIFF
--- a/docker_images/speechbrain/app/common.py
+++ b/docker_images/speechbrain/app/common.py
@@ -20,6 +20,8 @@ class ModelType(Enum):
     FASTSPEECH2 = "FASTSPEECH2"
     # text2text-generation
     GRAPHEMETOPHONEME = "GRAPHEMETOPHONEME"
+    # audio-diarization
+    SPEECHEMOTIONDIARIZATION = "SPEECHEMOTIONDIARIZATION"
 
 
 def get_type(model_id, interface_type="interface"):

--- a/docker_images/speechbrain/app/main.py
+++ b/docker_images/speechbrain/app/main.py
@@ -6,6 +6,7 @@ from typing import Dict, Type
 from api_inference_community.routes import pipeline_route, status_ok
 from app.pipelines import (
     AudioClassificationPipeline,
+    AudioDiarizationPipeline,
     AudioToAudioPipeline,
     AutomaticSpeechRecognitionPipeline,
     Pipeline,
@@ -39,6 +40,7 @@ logger = logging.getLogger(__name__)
 # directories. Implement directly within the directories.
 ALLOWED_TASKS: Dict[str, Type[Pipeline]] = {
     "audio-classification": AudioClassificationPipeline,
+    "audio-diarization": AudioDiarizationPipeline,
     "audio-to-audio": AudioToAudioPipeline,
     "automatic-speech-recognition": AutomaticSpeechRecognitionPipeline,
     "text-to-speech": TextToSpeechPipeline,

--- a/docker_images/speechbrain/app/pipelines/__init__.py
+++ b/docker_images/speechbrain/app/pipelines/__init__.py
@@ -1,6 +1,7 @@
 from app.pipelines.base import Pipeline, PipelineException  # isort:skip
 
 from app.pipelines.audio_classification import AudioClassificationPipeline
+from app.pipelines.audio_diarization import AudioDiarizationPipeline
 from app.pipelines.audio_to_audio import AudioToAudioPipeline
 from app.pipelines.automatic_speech_recognition import (
     AutomaticSpeechRecognitionPipeline,

--- a/docker_images/speechbrain/app/pipelines/audio_diarization.py
+++ b/docker_images/speechbrain/app/pipelines/audio_diarization.py
@@ -1,0 +1,36 @@
+from typing import Dict, List
+
+import numpy as np
+import torch
+from app.common import ModelType, get_type
+from app.pipelines import Pipeline
+from speechbrain.pretrained import Speech_Emotion_Diarization
+
+
+class AudioDiarizationPipeline(Pipeline):
+    def __init__(self, model_id: str):
+        model_type = get_type(model_id)
+        if model_type == ModelType.SPEECHEMOTIONDIARIZATION:
+            self.model = Speech_Emotion_Diarization.from_hparams(source=model_id)
+        else:
+            raise ValueError(f"{model_type.value} is invalid for audio-diarization")
+
+        # Please define a `self.sampling_rate` for this pipeline
+        # to automatically read the input correctly
+        self.sampling_rate = 16000
+
+    def __call__(self, inputs: np.array) -> Dict[str, List[Dict[str, float]]]:
+        """
+        Args:
+            inputs (:obj:`np.array`):
+                The raw waveform of audio received. By default at 16KHz.
+        Return:
+            A :obj:`dict`:. The object returned should be a dictionary like {"audio_id": [{"start": 0.0, "end": 2.0, "emotion": "n"}]} containing :
+                - "start": A float representing the starting timestamp of a speech event.
+                - "end": A float representing the ending timestamp of a speech event.
+                - "emotion"/"speaker": A str representing the content of the speech event.
+        """
+        batch = torch.from_numpy(inputs).unsqueeze(0)
+        rel_length = torch.tensor([1.0])
+        results = model.diarize_batch(batch, rel_length, ["hf_api_test_audio"])
+        return results

--- a/docker_images/speechbrain/tests/test_api.py
+++ b/docker_images/speechbrain/tests/test_api.py
@@ -17,6 +17,10 @@ TESTABLE_MODELS: Dict[str, List[str]] = {
         # Speaker recognition
         "speechbrain/spkrec-xvect-voxceleb",
     ],
+    "audio-diarization": [
+        # Emotion Diarization
+        "speechbrain/emotion-diarization-wavlm-large",
+    ],
     "audio-to-audio": [
         # Speech Enhancement
         "speechbrain/mtl-mimic-voicebank",
@@ -44,6 +48,7 @@ TESTABLE_MODELS: Dict[str, List[str]] = {
 
 ALL_TASKS = {
     "audio-classification",
+    "audio-diarization",
     "audio-to-audio",
     "automatic-speech-recognition",
     "audio-source-separation",

--- a/docker_images/speechbrain/tests/test_api_audio_diarization.py
+++ b/docker_images/speechbrain/tests/test_api_audio_diarization.py
@@ -1,0 +1,111 @@
+import json
+import os
+from unittest import TestCase, skipIf
+
+from app.main import ALLOWED_TASKS
+from parameterized import parameterized_class
+from starlette.testclient import TestClient
+from tests.test_api import TESTABLE_MODELS
+
+
+@skipIf(
+    "audio-diarization" not in ALLOWED_TASKS,
+    "audio-diarization not implemented",
+)
+
+@parameterized_class(
+    [{"model_id": model_id} for model_id in TESTABLE_MODELS["audio-diarization"]]
+)
+
+
+class AudioDiarizationTestCase(TestCase):
+    def setUp(self):
+        self.old_model_id = os.getenv("MODEL_ID")
+        self.old_task = os.getenv("TASK")
+        os.environ["MODEL_ID"] = self.model_id
+        os.environ["TASK"] = "audio-diarization"
+        from app.main import app
+
+        self.app = app
+
+    @classmethod
+    def setUpClass(cls):
+        from app.main import get_pipeline
+
+        get_pipeline.cache_clear()
+
+    def tearDown(self):
+        if self.old_model_id is not None:
+            os.environ["MODEL_ID"] = self.old_model_id
+        else:
+            del os.environ["MODEL_ID"]
+        if self.old_task is not None:
+            os.environ["TASK"] = self.old_task
+        else:
+            del os.environ["TASK"]
+
+    def read(self, filename: str) -> bytes:
+        dirname = os.path.dirname(os.path.abspath(__file__))
+        filename = os.path.join(dirname, "samples", filename)
+        with open(filename, "rb") as f:
+            bpayload = f.read()
+        return bpayload
+
+    def test_simple(self):
+        bpayload = self.read("sample1.flac")
+
+        with TestClient(self.app) as client:
+            response = client.post("/", data=bpayload)
+
+        self.assertEqual(
+            response.status_code,
+            200,
+        )
+
+        content = json.loads(response.content)
+        self.assertEqual(type(content), list)
+        self.assertEqual(type(content[0]), dict)
+
+
+    def test_malformed_audio(self):
+        bpayload = self.read("malformed.flac")
+
+        with TestClient(self.app) as client:
+            response = client.post("/", data=bpayload)
+
+        self.assertEqual(
+            response.status_code,
+            400,
+        )
+        self.assertEqual(response.content, b'{"error":"Malformed soundfile"}')
+
+    def test_dual_channel_audiofile(self):
+        bpayload = self.read("sample1_dual.ogg")
+
+        with TestClient(self.app) as client:
+            response = client.post("/", data=bpayload)
+
+        self.assertEqual(
+            response.status_code,
+            200,
+        )
+
+        content = json.loads(response.content)
+        self.assertEqual(type(content), list)
+        self.assertEqual(type(content[0]), dict)
+
+
+    def test_webm_audiofile(self):
+        bpayload = self.read("sample1.webm")
+
+        with TestClient(self.app) as client:
+            response = client.post("/", data=bpayload)
+
+        self.assertEqual(
+            response.status_code,
+            200,
+        )
+
+        content = json.loads(response.content)
+        self.assertEqual(type(content), list)
+        self.assertEqual(type(content[0]), dict)


### PR DESCRIPTION
Hi, 

Following #308, this PR adds support for the speech-emotion-diarization model. This `audio_diarization` interface can benefit other diarization tasks (emotion/speaker/vad/other speech events).

For more details:
[speechbrain/emotion-diarization-wavlm-large](https://huggingface.co/speechbrain/emotion-diarization-wavlm-large) 

Thanks!