### PR TITLE
Flair: Bump version

### DIFF
--- a/docker_images/flair/requirements.txt
+++ b/docker_images/flair/requirements.txt
@@ -1,4 +1,4 @@
 starlette==0.27.0
 pydantic==1.8.2
-flair @ git+https://github.com/flairNLP/flair@d4ed67bf663e4066517f00397412510d90043653
+flair @ git+https://github.com/flairNLP/flair@b18aff236098fc6623de8bdb4c8b50e4bfe7f91f
 api-inference-community==0.0.25


### PR DESCRIPTION
Hi,

Flair team here :hugs: 

With this PR the latest commit of Flair is used for the inference container.

We need this update to fix broken models incl. recently fine-tuned models with recent Flair version.

This update e.g. fixes:

* `'dict' object has no attribute 'embedding_length'` error from [this model](https://huggingface.co/flair/ner-german?text=George+Washington+ging+dann+nach+Washington)
* `No module named 'flair.trainers.plugins'` error from [this model](https://huggingface.co/hmteams/flair-hipe-2022-ajmc-en?text=Cp+.+Eur+.+Phoen+.+240+%2C+1+%2C+%CE%B1%E1%BC%B7%CE%BC%CE%B1+ddiov+%CF%86%CE%BB%CE%AD%CE%B3%CE%AD%CE%B9+.)

I locally tested the container and all these errors are gone - and ensured that is also works with already [other models](https://huggingface.co/flair/ner-english-large). This version is bump is also approved by @alanakbik.

