### PR TITLE
SpanMarker: Increment minimum version to most recent

### DIFF
--- a/docker_images/span_marker/requirements.txt
+++ b/docker_images/span_marker/requirements.txt
@@ -1,4 +1,4 @@
 starlette==0.27.0
 api-inference-community==0.0.25
 huggingface_hub==0.11.0
-span_marker>=1.0.0
+span_marker>=1.4.0

--- a/docker_images/span_marker/requirements.txt
+++ b/docker_images/span_marker/requirements.txt
@@ -1,4 +1,4 @@
 starlette==0.27.0
-api-inference-community==0.0.25
-huggingface_hub==0.11.0
+api-inference-community==0.0.32
+huggingface_hub>=0.17.3
 span_marker>=1.4.0


### PR DESCRIPTION
Hello!

## Pull Request overview
* Increment minimum version for SpanMarker.

## Details
I recently released [version 1.4.0](https://github.com/tomaarsen/SpanMarkerNER/blob/main/CHANGELOG.md) for SpanMarker, which includes a patch for XLM-RoBERTa models. I'd like for this patch to also be applied for the inference API, and I'm not sure how or when this version is ever updated. That said, I assume the change from this PR will do it.

- Tom Aarsen