### PR TITLE
👷 Automatically dispatch tasks to hf.js

### DIFF
--- a/.github/workflows/python-api-export-tasks.yaml
+++ b/.github/workflows/python-api-export-tasks.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - transmit-payload-to-hfjs
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will send a dispatch even to hf.js, where we need to create a matching action to receive the event with `repository_dispatch`: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch

This will allow us to automate updating https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/library-to-tasks.ts (with an action that will open a PR to this file)

cc @pcuenca @mishig25 @osanseviero @julien-c 

cc @Wauplin in case you might want that too for some reason

## Migration

Set a `REPO_DISPATCH_TOKEN` secret, a PAT that has read/write & metadata on `huggingface/huggingface.js`