### PR TITLE
Increase SetFit version to 1.0.1 & incr hf_hub

### DIFF
--- a/docker_images/setfit/requirements.txt
+++ b/docker_images/setfit/requirements.txt
@@ -1,4 +1,4 @@
 starlette==0.27.0
 api-inference-community==0.0.32
-huggingface_hub==0.11.0
-setfit==0.7.0
+huggingface_hub==0.19.4
+setfit==1.0.1


### PR DESCRIPTION
Hello!

## Pull Request overview
* Increase SetFit version to 1.0.1 from 0.7.0
* Also increase huggingface_hub to 0.19.4

## Details
SetFit v1.0 has been released, so it should be used to take advantage of the better label support introduced in that version.

I recognize that widgets aren't live yet, but they should be once an internal repo updates.

## Tests
I ran the tests: `5 passed, 13 warnings in 269.63s (0:04:29)`
and deployed the model locally with `python manage.py start`:

```
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
2023-12-08 10:48:29,513 - INFO - 127.0.0.1:61047 - "GET / HTTP/1.1" 200
2023-12-08 10:48:59,428 - INFO - 127.0.0.1:61048 - "POST / HTTP/1.1" 200
2023-12-08 10:49:20,446 - INFO - 127.0.0.1:61055 - "POST / HTTP/1.1" 200
```
And it worked fine.

- Tom Aarsen