### PR TITLE
Increment the Sentence Transformers version to 2.3.1

### DIFF
--- a/docker_images/sentence_transformers/requirements.txt
+++ b/docker_images/sentence_transformers/requirements.txt
@@ -1,6 +1,6 @@
 starlette==0.27.0
 api-inference-community==0.0.29
-sentence-transformers==2.2.2
+sentence-transformers==2.3.1
 protobuf==3.18.3
 huggingface_hub==0.13.4
 sacremoses==0.0.53


### PR DESCRIPTION
Hello!

## Pull Request overview
* Increment the Sentence Transformers version to 2.3.1

## Details
Sentence Transformers 2.3.X brings support for `model.safetensors` & adds new configuration options. As a result, models trained with 2.3.X will not work with 2.2.2, e.g.:
![image](https://github.com/huggingface/api-inference-community/assets/37621491/3189661e-b33e-4c81-aa70-78e6ea112998)

I ran `manage.py` locally with both 2.2.2 & 2.3.1 for https://huggingface.co/tomaarsen/mpnet-base-all-nli: the former failed while the latter worked.

- Tom Aarsen