### PR TITLE
Increment api-inference-community to 0.0.32 for Sentence Transformers

### DIFF
--- a/docker_images/sentence_transformers/requirements.txt
+++ b/docker_images/sentence_transformers/requirements.txt
@@ -1,5 +1,5 @@
 starlette==0.27.0
-api-inference-community==0.0.29
+api-inference-community==0.0.32
 sentence-transformers==2.3.1
 protobuf==3.18.3
 huggingface_hub==0.20.3


### PR DESCRIPTION
Hello!

## Pull Request overview
* Increment api-inference-community to 0.0.32

## Details
This should resolve the Pydantic v2 issues.

Locally, I can only get `python manage.py docker` to work by:
1. Replacing duplicate `os.path.dirname` with single `os.path.dirname` in `manage.py`
2. Removing `python app/main.py` from `docker_images/sentence_transformers/app/prestart.sh`.

`python manage.py start` works with only the 1st change.

---

- Tom Aarsen