### PR TITLE
Update SpeechBrain requirements.txt

### DIFF
--- a/docker_images/speechbrain/requirements.txt
+++ b/docker_images/speechbrain/requirements.txt
@@ -4,4 +4,6 @@ api-inference-community==0.0.32
 huggingface_hub>=0.7
 transformers==4.30.0
 git+https://github.com/speechbrain/speechbrain@v1.0.0
+https://github.com/kpu/kenlm/archive/master.zip
+pygtrie
 #Dummy.


### PR DESCRIPTION
Hello,

This PR aims at updating SpeechBrain requirements. Indeed, some HF models on our hub are using KenLM for n-gram rescoring. Hence, they require adding `pygtrie` and `kenlm` as part of the requirements in order to be used (note: these packages are not part of SpeechBrain requirements as they are optional).