### PR TITLE
Increment Sentence Transformers version to v2.5.1

### DIFF
--- a/docker_images/sentence_transformers/requirements.txt
+++ b/docker_images/sentence_transformers/requirements.txt
@@ -1,6 +1,6 @@
 starlette==0.27.0
 api-inference-community==0.0.32
-sentence-transformers==2.3.1
+sentence-transformers==2.5.1
 protobuf==3.18.3
 huggingface_hub==0.20.3
 sacremoses==0.0.53


### PR DESCRIPTION
Hello!

## Pull Request overview
* Increment Sentence Transformers version to v2.5.1

## Details
This should let the API Inference work with the latest models.

- Tom Aarsen