### PR TITLE
Initial SD3 support

### DIFF
--- a/docker_images/diffusers/requirements.txt
+++ b/docker_images/diffusers/requirements.txt
@@ -1,7 +1,7 @@
 starlette==0.27.0
 # to be replaced with api-inference-community==0.0.33 as soon as released
 git+https://github.com/huggingface/api-inference-community.git@b3ef3f3a6015ed988ce77f71935e45006be5b054
-git+https://github.com/huggingface/diffusers@4da810b94349206af9e71560cfac3685c94d7191
+git+https://github.com/huggingface/diffusers@6bfd13f07abbee29c61251f6573d0b103613f4ca
 transformers==4.35.2
 accelerate==0.25.0
 hf_transfer==0.1.3


### PR DESCRIPTION
This upgrades diffusers to the latest main to provide initial SD3 support. 

SD3 LoRAs are not yet supported due to https://github.com/huggingface/diffusers/issues/8615 

Plan is to wait on the response of the diffusers team on how easy/what's the prio to implement `fuse_lora` on SD3. If it is not coming soon I'll send another PR changing the logic to support load/unloading LoRAs without fusing for SD3