### PR TITLE
Update transformers, diffusers and accelerate for `diffusers`

### DIFF
--- a/docker_images/diffusers/requirements.txt
+++ b/docker_images/diffusers/requirements.txt
@@ -1,9 +1,9 @@
 starlette==0.27.0
 # to be replaced with api-inference-community==0.0.33 as soon as released
 git+https://github.com/huggingface/api-inference-community.git@b3ef3f3a6015ed988ce77f71935e45006be5b054
-git+https://github.com/huggingface/diffusers@6bfd13f07abbee29c61251f6573d0b103613f4ca
-transformers==4.35.2
-accelerate==0.25.0
+git+https://github.com/huggingface/diffusers@2b945b0a2f1fbdb960ad045f9fd32ab057afb7ab
+transformers==4.41.2
+accelerate==0.31.0
 hf_transfer==0.1.3
 pydantic>=2
 ftfy==6.1.1

--- a/docker_images/diffusers/requirements.txt
+++ b/docker_images/diffusers/requirements.txt
@@ -1,7 +1,7 @@
 starlette==0.27.0
 # to be replaced with api-inference-community==0.0.33 as soon as released
 git+https://github.com/huggingface/api-inference-community.git@b3ef3f3a6015ed988ce77f71935e45006be5b054
-git+https://github.com/huggingface/diffusers@2b945b0a2f1fbdb960ad045f9fd32ab057afb7ab
+git+https://github.com/huggingface/diffusers@668e34c6e0019b29c887bcc401c143a7d088cb25
 transformers==4.41.2
 accelerate==0.31.0
 hf_transfer==0.1.3


### PR DESCRIPTION
The pinned old Transformers seemed to be breaking the pipeline loading.

Also upgraded `diffusers` to include this PR: https://github.com/huggingface/diffusers/pull/8616 