### PR TITLE
Protobuf required dependency

### DIFF
--- a/docker_images/diffusers/Dockerfile
+++ b/docker_images/diffusers/Dockerfile
@@ -27,7 +27,11 @@ RUN pyenv install $PYTHON_VERSION && \
 
 # Upgrade pip and install your desired packages
 ARG PIP_VERSION=22.3.1
-RUN pip install --no-cache-dir --upgrade pip==${PIP_VERSION} setuptools wheel && \
+
+# FIXME: We temporarily need to specify the setuptools version <70 due to the following issue
+# https://stackoverflow.com/questions/78604018/importerror-cannot-import-name-packaging-from-pkg-resources-when-trying-to
+# https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15863#issuecomment-2125026282
+RUN pip install --no-cache-dir --upgrade pip==${PIP_VERSION} setuptools'<70' wheel && \
     pip install --no-cache-dir torch==2.0.1 torchvision==0.15.2 torchaudio==2.0.2
 
 WORKDIR /app

--- a/docker_images/diffusers/requirements.txt
+++ b/docker_images/diffusers/requirements.txt
@@ -17,10 +17,5 @@ uvicorn>=0.23.2
 gunicorn>=21.2.0
 psutil>=5.9.5
 aiohttp>=3.8.5
-# Tmp: replace with version once there is a tag above 0.8.1
-# This commit includes a fix that concerns
-# https://github.com/huggingface/diffusers/issues/6809
-# peft==0.7.1
-git+https://github.com/huggingface/peft.git@a30e006bb2f82824ab24435b9f07932738b44966
-# peft==0.11.1
+peft==0.11.1
 protobuf==5.27.1

--- a/docker_images/diffusers/requirements.txt
+++ b/docker_images/diffusers/requirements.txt
@@ -17,8 +17,5 @@ uvicorn>=0.23.2
 gunicorn>=21.2.0
 psutil>=5.9.5
 aiohttp>=3.8.5
-# Tmp: replace with version once there is a tag above 0.8.1
-# This commit includes a fix that concerns
-# https://github.com/huggingface/diffusers/issues/6809
-# peft==0.7.1
-git+https://github.com/huggingface/peft.git@a30e006bb2f82824ab24435b9f07932738b44966
+peft==0.11.1
+protobuf==5.27.1

--- a/docker_images/diffusers/requirements.txt
+++ b/docker_images/diffusers/requirements.txt
@@ -17,5 +17,10 @@ uvicorn>=0.23.2
 gunicorn>=21.2.0
 psutil>=5.9.5
 aiohttp>=3.8.5
-peft==0.11.1
+# Tmp: replace with version once there is a tag above 0.8.1
+# This commit includes a fix that concerns
+# https://github.com/huggingface/diffusers/issues/6809
+# peft==0.7.1
+git+https://github.com/huggingface/peft.git@a30e006bb2f82824ab24435b9f07932738b44966
+# peft==0.11.1
 protobuf==5.27.1


### PR DESCRIPTION
fix for sd3

```
T5Converter requires the protobuf library but it was not found in your environment. Checkout the instructions on the
installation page of its repo: https://github.com/protocolbuffers/protobuf/tree/master/python#installation and follow the ones
that match your environment. Please note that you may need to restart your runtime after installation.
```