### PR TITLE
[`sentence-transformers`] Add sentencepiece dependency for running models with slow tokenizers only

### DIFF
--- a/docker_images/sentence_transformers/requirements.txt
+++ b/docker_images/sentence_transformers/requirements.txt
@@ -1,6 +1,7 @@
 starlette==0.27.0
 api-inference-community==0.0.32
 sentence-transformers==3.0.1
+sentencepiece==0.2.0
 transformers==4.41.1
 tokenizers==0.19.1
 protobuf==3.18.3


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add sentencepiece dependency for running models with slow tokenizers only

## Details
See e.g. https://huggingface.co/rokn/slovlo-v1:
![image](https://github.com/huggingface/api-inference-community/assets/37621491/756b6c6f-9d30-4d6f-959c-3cc28570526d)

`sentencepiece` was removed as a required dependency, because most models don't require it anymore. Nowadays, we simply throw an error if it's required but not installed. However, the API Inference should have it installed to ensure that we can also run these models with slow tokenizers. I've verified locally that `sentencepiece==0.2.0` works for e.g. that `slovlo-v1` model.

- Tom Aarsen