### PR TITLE
Upgrade diffusers to main

### DIFF
--- a/docker_images/diffusers/requirements.txt
+++ b/docker_images/diffusers/requirements.txt
@@ -1,7 +1,8 @@
 starlette==0.27.0
 # to be replaced with api-inference-community==0.0.33 as soon as released
 git+https://github.com/huggingface/api-inference-community.git@b3ef3f3a6015ed988ce77f71935e45006be5b054
-diffusers==0.29.2
+# to be replaced with diffusers 0.30.0 as soon as released
+git+https://github.com/huggingface/diffusers.git@31b211bfe36f7f04d61bcfb1253792b99d5c89d9
 transformers==4.41.2
 accelerate==0.31.0
 hf_transfer==0.1.3


### PR DESCRIPTION
Support SD3 LoRA fusion as https://github.com/huggingface/diffusers/pull/8616 didn't make it to the [0.29.2](https://github.com/huggingface/diffusers/releases/tag/v0.29.2) patch release