### PR TITLE
Flair: Add support for PoS Tagging Models & Version Update

### DIFF
--- a/docker_images/flair/app/pipelines/token_classification.py
+++ b/docker_images/flair/app/pipelines/token_classification.py
@@ -27,21 +27,30 @@ class TokenClassificationPipeline(Pipeline):
         """
         sentence: Sentence = Sentence(inputs)
 
-        # Also show scores for recognized NEs
-        self.tagger.predict(sentence, label_name="predicted")
+        self.tagger.predict(sentence)
 
         entities = []
-        for span in sentence.get_spans("predicted"):
-            if len(span.tokens) == 0:
-                continue
-            current_entity = {
-                "entity_group": span.tag,
-                "word": span.text,
-                "start": span.tokens[0].start_position,
-                "end": span.tokens[-1].end_position,
-                "score": span.score,
-            }
-
-            entities.append(current_entity)
+        for label in labels:
+            if isinstance(label, Label):
+                current_data_point = label.data_point
+                current_entity = {
+                    "entity_group": current_data_point.tag,
+                    "word": current_data_point.text,
+                    "start": current_data_point.start_position,
+                    "end": current_data_point.end_position,
+                    "score": current_data_point.score,
+                }
+                entities.append(current_entity)
+            elif isinstance(label, Span):
+                if len(label.tokens) == 0:
+                    continue
+                current_entity = {
+                    "entity_group": label.tag,
+                    "word": label.text,
+                    "start": label.tokens[0].start_position,
+                    "end": label.tokens[-1].end_position,
+                    "score": label.score,
+                }
+                entities.append(current_entity)
 
         return entities

--- a/docker_images/flair/requirements.txt
+++ b/docker_images/flair/requirements.txt
@@ -1,4 +1,4 @@
 starlette==0.27.0
 pydantic==1.8.2
-flair @ git+https://github.com/flairNLP/flair@b18aff236098fc6623de8bdb4c8b50e4bfe7f91f
+flair @ git+https://github.com/flairNLP/flair@e17ab1234fcfed2b089d8ef02b99949d520382d2
 api-inference-community==0.0.25


### PR DESCRIPTION
Hi all,

Flair team here 😄

This PR adds support for PoS Tagging models and is fixing this [reported bug](https://huggingface.co/flair/upos-english/discussions/1).

Additionally, the Flair version is bumped to our latest [0.14.0](https://github.com/flairNLP/flair/releases/tag/v0.14.0) release.

## Tests

I locally tested this PR. With the `flair/ner-english` NER model:

```bash
$ curl -s -X POST -d "George Washington went to Washington." http://localhost:8000 | jq
[
  {
    "entity_group": "PER",
    "word": "George Washington",
    "start": 0,
    "end": 17,
    "score": 0.998886227607727
  },
  {
    "entity_group": "LOC",
    "word": "Washington",
    "start": 26,
    "end": 36,
    "score": 0.9942097663879395
  }
]
```

The PoS Tagging model `flair/upos-english` is now working:

```bash
$ curl -s -X POST -d "Ich liebe Berlin, as they say" http://localhost:8000 | jq
[
  {
    "entity_group": "INTJ",
    "word": "Ich",
    "start": 0,
    "end": 3,
    "score": 0.5181307792663574
  },
  {
    "entity_group": "PUNCT",
    "word": "liebe",
    "start": 4,
    "end": 9,
    "score": 0.94031822681427
  },
  {
    "entity_group": "PROPN",
    "word": "Berlin",
    "start": 10,
    "end": 16,
    "score": 0.7861781120300293
  },
  {
    "entity_group": "ADV",
    "word": ",",
    "start": 16,
    "end": 17,
    "score": 0.4596414566040039
  },
  {
    "entity_group": "ADV",
    "word": "as",
    "start": 18,
    "end": 20,
    "score": 0.7350289821624756
  },
  {
    "entity_group": "PRON",
    "word": "they",
    "start": 21,
    "end": 25,
    "score": 0.8404370546340942
  },
  {
    "entity_group": "VERB",
    "word": "say",
    "start": 26,
    "end": 29,
    "score": 0.9999231100082397
  }
]
```