### PR TITLE
Support FLUX models in diffusers

### DIFF
--- a/docker_images/diffusers/requirements.txt
+++ b/docker_images/diffusers/requirements.txt
@@ -2,7 +2,7 @@ starlette==0.27.0
 # to be replaced with api-inference-community==0.0.33 as soon as released
 git+https://github.com/huggingface/api-inference-community.git@b3ef3f3a6015ed988ce77f71935e45006be5b054
 # to be replaced with diffusers 0.30.0 as soon as released
-git+https://github.com/huggingface/diffusers.git@31b211bfe36f7f04d61bcfb1253792b99d5c89d9
+git+https://github.com/huggingface/diffusers.git@fc6a91e3834c35e57b398ad1c0d99f6f83557e04
 transformers==4.41.2
 accelerate==0.31.0
 hf_transfer==0.1.3


### PR DESCRIPTION
Upgrade diffusers to support FLUX.1 models in the inference API (and hence get the widget working)