### PR TITLE
status code: input parsing, no EnvironmentError case handling

### DIFF
--- a/api_inference_community/routes.py
+++ b/api_inference_community/routes.py
@@ -129,11 +129,6 @@ async def pipeline_route(request: Request) -> Response:
 
     try:
         inputs, params = normalize_payload(payload, task, sampling_rate=sampling_rate)
-    except EnvironmentError as e:
-        # Since we catch the environment edge cases earlier above, this should not happen here anymore
-        # harmless to keep it, just in case
-        logger.error("Error while parsing input %s", e)
-        return JSONResponse({"error": str(e)}, status_code=500)
     except ValidationError as e:
         errors = []
         for error in e.errors():


### PR DESCRIPTION
example:
task: image-to-image
if the user provides sth that cannot be parsed by PIL (eg an image) PIL will raise an OSError (and EnvironmentError is an alias for OSError, kept for backward compat) But actually this "OSError" is due to some bad payload provided by the user. So let's consider that we have filtered all internal errors when loading pipeline