### PR TITLE
[`deps`] Increment Sentence Transformers to v3.3.1

### DIFF
--- a/docker_images/sentence_transformers/requirements.txt
+++ b/docker_images/sentence_transformers/requirements.txt
@@ -1,9 +1,9 @@
 starlette==0.27.0
 api-inference-community==0.0.32
-sentence-transformers==3.0.1
-transformers==4.41.1
-tokenizers==0.19.1
+sentence-transformers==3.3.1
+transformers==4.48.0
+tokenizers==0.21.0
 protobuf==3.18.3
-huggingface_hub==0.23.3
+huggingface_hub==0.27.1
 sacremoses==0.0.53
 # dummy.


### PR DESCRIPTION
Hello!

## Pull Request overview
* Increment Sentence Transformers to v3.3.1

## Details
I tested this locally with [static-similarity-mrl-multilingual-v1](https://huggingface.co/sentence-transformers/static-similarity-mrl-multilingual-v1), and it worked. Before this PR, this error is given:
![image](https://github.com/user-attachments/assets/6fb2fbb9-984c-49a3-a1a7-9504d5aa81d9)

Sentence Transformers and Transformers, are backwards compatible, so this shouldn't cause any issues.

- Tom Aarsen